### PR TITLE
ALEC-64: Inventory does not automatically refresh with the direct datasource

### DIFF
--- a/datasource/opennms-direct/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/datasource/opennms-direct/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -13,6 +13,7 @@
     <reference id="nodeDao" interface="org.opennms.integration.api.v1.dao.NodeDao" />
     <reference id="edgeDao" interface="org.opennms.integration.api.v1.dao.EdgeDao" />
     <reference id="eventForwarder" interface="org.opennms.integration.api.v1.events.EventForwarder" />
+    <reference id="eventService" interface="org.opennms.integration.api.v1.events.EventSubscriptionService" />
 
     <bean id="scriptService" class="org.opennms.alec.datasource.opennms.jvm.OpennmsDirectScriptedInventory">
         <argument value="${scriptFile}"/>
@@ -44,11 +45,12 @@
 
     <!-- Direct Datasource -->
     <bean id="directInventoryDatasource" class="org.opennms.alec.datasource.opennms.jvm.DirectInventoryDatasource"
-          init-method="init">
+          init-method="init" destroy-method="destroy">
         <argument ref="nodeDao"/>
         <argument ref="alarmDao"/>
         <argument ref="edgeDao"/>
         <argument ref="mapper"/>
+        <argument ref="eventService"/>
     </bean>
     <service ref="directInventoryDatasource" interface="org.opennms.alec.datasource.api.InventoryDatasource"/>
     <service ref="directInventoryDatasource" interface="org.opennms.integration.api.v1.alarms.AlarmLifecycleListener"/>


### PR DESCRIPTION
This PR adds node processing to the direct inventory data source in ALEC so we will derive inventory directly from node events instead of just relying on alarms. We will only remove inventory when it is no longer referenced by any of the sources we derive from (alarms, edges, nodes).

Also added additional trace logging. Fixed a memory leak where we would hold onto all alarm Ids we have ever seen.

Tested manually with topology via open daylight plugin.

Jira: https://issues.opennms.org/browse/ALEC-64