### PR TITLE
ALEC-66: Expand test coverage for UDL

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,7 +65,7 @@ workflows:
           filters:
             tags:
               only: /.*/
-      - smoke-test:
+      - smoke-test-commit:
           requires:
             - build
           filters:
@@ -75,7 +75,7 @@ workflows:
       # Run deploy jobs on version tags, release branches and develop
       - deploy-maven:
           requires:
-            - smoke-test
+            - smoke-test-commit
           filters:
             # Maven deploy requires GPG signing for releases - we do this manually
             branches:
@@ -84,7 +84,7 @@ workflows:
                 - /release-.*/
       - deploy-packages:
           requires:
-            - smoke-test
+            - smoke-test-commit
             - build-debian
           filters:
             tags:
@@ -106,6 +106,135 @@ workflows:
       - yank-snapshot-packages:
           requires:
             - deploy-packages
+
+  nightly:
+    triggers:
+    - schedule:
+        # Run daily @ 5:00am UTC
+        cron: "0 5 * * *"
+        filters:
+          branches:
+            only:
+            - develop
+            - /release-.*/
+    jobs:
+    - pre-build:
+        filters:
+          tags:
+            only: /.*/
+    - build:
+        requires:
+        - pre-build
+        filters:
+          tags:
+            only: /.*/
+    - smoke-test-nightly:
+        requires:
+        - build
+        filters:
+          tags:
+            only: /.*/
+
+commands:
+  smoke-test:
+    description: "Run the smoke tests"
+    parameters:
+      context:
+        type: string
+    steps:
+      - attach_workspace:
+          at: ~/
+
+        # Link root user's m2 repo from the cache with our user's m2 repo (the circleci user)
+      - run:
+          name: Link maven repo with cache
+          command: |
+            sudo chmod 777 /root
+            ln -s /root/.m2 ~/.m2
+
+      - restore_cache:
+          keys:
+          # attempt to use the cache from the last smoke-test run
+          - v2-smoke-dependencies-{{ checksum "smoke-test/pom.xml" }}-{{ checksum "pom.xml" }}
+          # use the cache built for the same root pom
+          - v5-dependencies-{{ checksum "pom.xml" }}
+          # fallback to using the latest cache if no exact match is found
+          - v5-dependencies-
+
+      - restore_cache:
+          keys:
+          - v1-docker-{{ checksum "smoke-test/src/main/resources/docker_fixed_images" }}
+
+      - run:
+          name: Import docker images
+          command: |
+            if [ -z "$(ls /tmp/docker 2> /dev/null)" ]; then exit 0; fi
+            source smoke-test/src/main/resources/docker_fixed_images
+            for dockerTargz in $(ls /tmp/docker); do
+              dockerName="${dockerTargz%.*}"
+              echo "Importing ${!dockerName} from $dockerTargz"
+              docker load --input /tmp/docker/"$dockerTargz"
+            done
+            docker image ls
+
+      - run:
+          name: Run the tests
+          command: |
+            mkdir $TEST_RECORDING_DIR
+            mvn install --projects org.opennms.alec:smoke-test --also-make -DskipTests=true
+            cd smoke-test
+            if [ "<< parameters.context >>" = "commit" ]; then
+              mvn surefire:test -Dtest=OnCommitSmokeTest -DsmokeTest=true
+            elif [ "<< parameters.context >>" = "nightly" ]; then
+              mvn test -DsmokeTest=true
+            fi
+
+      - save_cache:
+          paths:
+          - /root/.m2
+          key: v2-smoke-dependencies-{{ checksum "smoke-test/pom.xml" }}-{{ checksum "pom.xml" }}
+
+      - run:
+          name: Save cacheable Docker images
+          command: |
+            if [ -d /tmp/docker ]; then exit 0; fi
+            mkdir /tmp/docker
+            tagsFile="smoke-test/src/main/resources/docker_fixed_images"
+            source "$tagsFile"
+            for dockerImg in $(awk -F '=' '/^[^#]/ {print $1}' "$tagsFile"); do
+              echo "Saving docker image ${!dockerImg} as ${dockerImg}.tgz"
+              docker save -o /tmp/docker/"$dockerImg".tgz "${!dockerImg}"
+            done
+
+      - save_cache:
+          paths:
+          - /tmp/docker
+          key: v1-docker-{{ checksum "smoke-test/src/main/resources/docker_fixed_images" }}
+
+      - run:
+          name: Save test results
+          command: |
+            mkdir -p ~/junit/
+            find . -type f -regex ".*/target/failsafe-reports/.*xml" -exec cp {} ~/junit/ \;
+            find . -type f -regex ".*/target/surefire-reports/.*xml" -exec cp {} ~/junit/ \;
+          when: always
+
+      - store_test_results:
+          path: ~/junit
+
+      - store_artifacts:
+          path: ~/logs
+
+      # Unfortunately I can't reference the env variable containing the recording path here so I have to
+      # duplicate it
+      - store_artifacts:
+          path: /tmp/test-recordings
+
+      # Future Improvements:
+      # - Store the logs from the sentinel and OpenNMS containers for the test run in addition to the junit logs
+      #   - Mount the logs directories from the containers so we can copy the logs out easier
+      # - Add nightly test run back once tests are proven stable
+      #   - We might want to test nightly against the floating (latest) images for opennms and sentinel
 
 jobs:
   pre-build:
@@ -212,99 +341,19 @@ jobs:
           paths:
             - project/assembly/
 
-  smoke-test:
+  smoke-test-commit:
     executor: smoke-test-executor
 
     steps:
-      - attach_workspace:
-          at: ~/
+    - smoke-test:
+        context: commit
 
-      # Link root user's m2 repo from the cache with our user's m2 repo (the circleci user)
-      - run:
-          name: Link maven repo with cache
-          command: |
-            sudo chmod 777 /root
-            ln -s /root/.m2 ~/.m2
+  smoke-test-nightly:
+    executor: smoke-test-executor
 
-      - restore_cache:
-          keys:
-          # attempt to use the cache from the last smoke-test run
-          - v2-smoke-dependencies-{{ checksum "smoke-test/pom.xml" }}-{{ checksum "pom.xml" }}
-          # use the cache built for the same root pom
-          - v5-dependencies-{{ checksum "pom.xml" }}
-          # fallback to using the latest cache if no exact match is found
-          - v5-dependencies-
-          
-      - restore_cache:
-          keys:
-          - v1-docker-{{ checksum "smoke-test/src/main/resources/docker_fixed_images" }}
-
-      - run:
-          name: Import docker images
-          command: |
-            if [ -z "$(ls /tmp/docker 2> /dev/null)" ]; then exit 0; fi
-            source smoke-test/src/main/resources/docker_fixed_images
-            for dockerTargz in $(ls /tmp/docker); do
-              dockerName="${dockerTargz%.*}"
-              echo "Importing ${!dockerName} from $dockerTargz"
-              docker load --input /tmp/docker/"$dockerTargz"
-            done
-            docker image ls
-  
-      - run:
-          name: Run the tests
-          command: |
-            mkdir $TEST_RECORDING_DIR
-            mvn install --projects org.opennms.alec:smoke-test --also-make -DskipTests=true
-            cd smoke-test
-            mvn test -DsmokeTest=true
-            
-      - save_cache:
-          paths:
-          - /root/.m2
-          key: v2-smoke-dependencies-{{ checksum "smoke-test/pom.xml" }}-{{ checksum "pom.xml" }}
-
-      - run:
-          name: Save cacheable Docker images
-          command: |
-            if [ -d /tmp/docker ]; then exit 0; fi
-            mkdir /tmp/docker
-            tagsFile="smoke-test/src/main/resources/docker_fixed_images"
-            source "$tagsFile"
-            for dockerImg in $(awk -F '=' '/^[^#]/ {print $1}' "$tagsFile"); do
-              echo "Saving docker image ${!dockerImg} as ${dockerImg}.tgz"
-              docker save -o /tmp/docker/"$dockerImg".tgz "${!dockerImg}"
-            done
-
-      - save_cache:
-          paths:
-          - /tmp/docker
-          key: v1-docker-{{ checksum "smoke-test/src/main/resources/docker_fixed_images" }}
-  
-      - run:
-          name: Save test results
-          command: |
-            mkdir -p ~/junit/
-            find . -type f -regex ".*/target/failsafe-reports/.*xml" -exec cp {} ~/junit/ \;
-            find . -type f -regex ".*/target/surefire-reports/.*xml" -exec cp {} ~/junit/ \;
-          when: always
-  
-      - store_test_results:
-          path: ~/junit
-
-      - store_artifacts:
-          path: ~/logs
-
-      # Unfortunately I can't reference the env variable containing the recording path here so I have to
-      # duplicate it
-      - store_artifacts:
-          path: /tmp/test-recordings
-
-      # Future Improvements:
-      # - Store the logs from the sentinel and OpenNMS containers for the test run in addition to the junit logs
-      #   - Mount the logs directories from the containers so we can copy the logs out easier
-      # - Add nightly test run back once tests are proven stable
-      #   - We might want to test nightly against the floating (latest) images for opennms and sentinel
+    steps:
+    - smoke-test:
+        context: nightly
 
   build-docs:
     executor: docs-executor
@@ -376,4 +425,3 @@ jobs:
           command: |
             source .circleci/env/package_cloud
             .circleci/scripts/packagecloud-yank-snapshot-packages.py
-

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -184,7 +184,7 @@ commands:
             mvn install --projects org.opennms.alec:smoke-test --also-make -DskipTests=true
             cd smoke-test
             if [ "<< parameters.context >>" = "commit" ]; then
-              mvn surefire:test -Dtest=OnCommitSmokeTest -DsmokeTest=true
+              mvn surefire:test -Dtest=OnCommitSmokeTestSuite -DsmokeTest=true
             elif [ "<< parameters.context >>" = "nightly" ]; then
               mvn test -DsmokeTest=true
             fi

--- a/smoke-test/src/main/java/org/opennms/alec/smoke/opennms/OpenNMSRestClient.java
+++ b/smoke-test/src/main/java/org/opennms/alec/smoke/opennms/OpenNMSRestClient.java
@@ -30,15 +30,13 @@ package org.opennms.alec.smoke.opennms;
 
 import static org.awaitility.Awaitility.await;
 
-import java.io.File;
 import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.net.MalformedURLException;
-import java.net.URISyntaxException;
 import java.net.URL;
-import java.nio.file.Paths;
 import java.util.Base64;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
@@ -72,6 +70,18 @@ public class OpenNMSRestClient {
 
     private final String authorizationHeader;
 
+    private static final String ADD_NODE_REQUEST = "<node foreign-id=\"%1$s\" node-label=\"%1$s\" " +
+            "xmlns=\"http://xmlns" +
+            ".opennms.org/xsd/config/model-import\"/>";
+
+    private static final String ADD_REQUISITION_REQUEST = "<model-import foreign-source=\"test\" xmlns=\"http://xmlns" +
+            ".opennms.org/xsd/config/model-import\"/>";
+
+    private static final String ADD_UDL_REQUEST = "{\"node-id-a\": %d, \"node-id-z\": %d, \"component-label-a\": " +
+            "\"tp1\", \"component-label-z\": \"tp2\", \"link-id\": \"n1:tp1->n2:tp2\", \"owner\": \"me\"}";
+
+    private final Gson gson = new Gson();
+
     public OpenNMSRestClient(InetSocketAddress addr) throws MalformedURLException {
         this(addr, DEFAULT_USERNAME, DEFAULT_PASSWORD);
     }
@@ -91,11 +101,11 @@ public class OpenNMSRestClient {
 
     public String getDisplayVersion() {
         try {
-        final WebTarget target = getTarget().path("info");
-        final String json = getBuilder(target).get(String.class);
+            final WebTarget target = getTarget().path("info");
+            final String json = getBuilder(target).get(String.class);
 
-        final ObjectMapper mapper = new ObjectMapper();
-        
+            final ObjectMapper mapper = new ObjectMapper();
+
             JsonNode actualObj = mapper.readTree(json);
             return actualObj.get("displayVersion").asText();
         } catch (IOException e) {
@@ -163,31 +173,41 @@ public class OpenNMSRestClient {
         sendEvent(e3);
         await().atMost(15, TimeUnit.SECONDS).until(() -> testForAlarmWithReductionKey(e3.reductionKey()));
     }
-    
-    public int addTestNode() throws URISyntaxException {
+
+    public int addTestNode() {
         // The requisition foreign source is hardcoded to "test" in the XML file
         addRequisition();
-        addNodeToRequisition("test");
+        addNodeToRequisition("test", "test");
         importRequisition("test");
         return waitForNode("test:test");
     }
-    
-    private void addRequisition() throws URISyntaxException {
+
+    public Map<String, Integer> addTestNodes(String... nodeLabels) {
+        // The requisition foreign source is hardcoded to "test" in the XML file
+        addRequisition();
+        Map<String, Integer> nodeLabelsToNodeIds = new HashMap<>();
+        for (String nodeLabel : nodeLabels) {
+            addNodeToRequisition("test", nodeLabel);
+        }
+        importRequisition("test");
+        for (String nodeLabel : nodeLabels) {
+            nodeLabelsToNodeIds.put(nodeLabel, waitForNode(String.format("test:%s", nodeLabel)));
+        }
+        return nodeLabelsToNodeIds;
+    }
+
+    private void addRequisition() {
         final WebTarget target = getTarget().path("requisitions");
-        File requisitionFile = new File(getClass().getClassLoader().getResource(Paths.get("requests", "requisition" +
-                ".xml").toString()).toURI());
-        final Response response = getBuilder(target).post(Entity.xml(requisitionFile));
+        final Response response = getBuilder(target).post(Entity.xml(ADD_REQUISITION_REQUEST));
         if (!Response.Status.Family.SUCCESSFUL.equals(response.getStatusInfo().getFamily())) {
             throw new IllegalArgumentException(String.format("Requisition add failed with %d: %s", response.getStatus(),
                     response));
         }
     }
 
-    private void addNodeToRequisition(String requisitionName) throws URISyntaxException {
+    private void addNodeToRequisition(String requisitionName, String nodeLabel) {
         final WebTarget target = getTarget().path("requisitions").path(requisitionName).path("nodes");
-        File nodeFile = new File(getClass().getClassLoader().getResource(Paths.get("requests", "node" +
-                ".xml").toString()).toURI());
-        final Response response = getBuilder(target).post(Entity.xml(nodeFile));
+        final Response response = getBuilder(target).post(Entity.xml(String.format(ADD_NODE_REQUEST, nodeLabel)));
         if (!Response.Status.Family.SUCCESSFUL.equals(response.getStatusInfo().getFamily())) {
             throw new IllegalArgumentException(String.format("Node add failed with %d: %s", response.getStatus(),
                     response));
@@ -212,7 +232,35 @@ public class OpenNMSRestClient {
         String responseBody = response.readEntity(String.class);
 
         // Return the ID of the node we waited for
-        return Integer.parseInt((String) new Gson().fromJson(responseBody, Map.class).get("id"));
+        return Integer.parseInt((String) gson.fromJson(responseBody, Map.class).get("id"));
+    }
+
+    public void addUDLBetweenNodes(int nodeAId, int nodeZId) {
+        final WebTarget target = getTargetV2().path("userdefinedlinks");
+        final Response response = getBuilder(target).post(Entity.json(String.format(ADD_UDL_REQUEST, nodeAId,
+                nodeZId)));
+        waitForLink(nodeAId, nodeZId);
+    }
+
+    @SuppressWarnings("unchecked")
+    private void waitForLink(int nodeAId, int nodeZId) {
+        final WebTarget target = getTargetV2().path("userdefinedlinks");
+        await().atMost(1, TimeUnit.MINUTES)
+                .pollInterval(5, TimeUnit.SECONDS)
+                .until(() -> {
+                    Response response = getBuilder(target).accept(MediaType.APPLICATION_JSON_TYPE).get();
+                    String responseBody = response.readEntity(String.class);
+                    Map<String, Object> jsonBody = gson.fromJson(responseBody, Map.class);
+                    List<Map<String, Object>> userDefinedLinksBody = (List<Map<String, Object>>) jsonBody.get(
+                            "user_defined_link");
+                    for (Map<String, Object> udlParams : userDefinedLinksBody) {
+                        if (udlParams.get("node-id-a").equals((double) nodeAId) &&
+                                udlParams.get("node-id-z").equals((double) nodeZId)) {
+                            return true;
+                        }
+                    }
+                    return false;
+                });
     }
 
     public void clearAllAlarms() {
@@ -229,6 +277,11 @@ public class OpenNMSRestClient {
     private WebTarget getTarget() {
         final Client client = ClientBuilder.newClient();
         return client.target(url.toString()).path("rest");
+    }
+
+    private WebTarget getTargetV2() {
+        final Client client = ClientBuilder.newClient();
+        return client.target(url.toString()).path("api").path("v2");
     }
 
     private Invocation.Builder getBuilder(final WebTarget target) {

--- a/smoke-test/src/main/resources/overlays/opennms-integrated-overlay/etc/featuresBoot.d/alec.boot
+++ b/smoke-test/src/main/resources/overlays/opennms-integrated-overlay/etc/featuresBoot.d/alec.boot
@@ -2,3 +2,4 @@ alec-datasource-opennms-direct wait-for-kar=opennms-alec-plugin
 alec-engine-cluster wait-for-kar=opennms-alec-plugin
 alec-processor-standalone wait-for-kar=opennms-alec-plugin
 alec-driver-main wait-for-kar=opennms-alec-plugin
+alec-features-graph-shell wait-for-kar=opennms-alec-plugin

--- a/smoke-test/src/main/resources/overlays/sentinel-overlay-redundant/etc/featuresBoot.d/alec.boot
+++ b/smoke-test/src/main/resources/overlays/sentinel-overlay-redundant/etc/featuresBoot.d/alec.boot
@@ -3,3 +3,4 @@ alec-datasource-opennms-kafka wait-for-kar=opennms-alec-plugin
 alec-engine-cluster wait-for-kar=opennms-alec-plugin
 alec-processor-redundant wait-for-kar=opennms-alec-plugin
 alec-driver-main wait-for-kar=opennms-alec-plugin
+alec-features-graph-shell wait-for-kar=opennms-alec-plugin

--- a/smoke-test/src/main/resources/requests/node.xml
+++ b/smoke-test/src/main/resources/requests/node.xml
@@ -1,1 +1,0 @@
-<node foreign-id="test" node-label="test" xmlns="http://xmlns.opennms.org/xsd/config/model-import"/>

--- a/smoke-test/src/main/resources/requests/requisition.xml
+++ b/smoke-test/src/main/resources/requests/requisition.xml
@@ -1,1 +1,0 @@
-<model-import foreign-source="test" xmlns="http://xmlns.opennms.org/xsd/config/model-import"/>

--- a/smoke-test/src/test/java/org/opennms/alec/smoke/ALECSmokeTestBase.java
+++ b/smoke-test/src/test/java/org/opennms/alec/smoke/ALECSmokeTestBase.java
@@ -29,8 +29,6 @@
 package org.opennms.alec.smoke;
 
 import static org.awaitility.Awaitility.await;
-import static org.hamcrest.Matchers.hasSize;
-import static org.junit.Assert.assertThat;
 import static org.opennms.alec.datasource.opennms.OpennmsDatasource.DEFAULT_ALARM_FEEDBACK_TOPIC;
 import static org.opennms.alec.datasource.opennms.OpennmsDatasource.DEFAULT_ALARM_TOPIC;
 import static org.opennms.alec.datasource.opennms.OpennmsDatasource.DEFAULT_EDGES_TOPIC;
@@ -38,14 +36,11 @@ import static org.opennms.alec.datasource.opennms.OpennmsDatasource.DEFAULT_INVE
 import static org.opennms.alec.datasource.opennms.OpennmsDatasource.DEFAULT_NODE_TOPIC;
 import static org.opennms.alec.smoke.containers.OpenNMSContainer.DB_ALIAS;
 
-import java.io.File;
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.Properties;
 import java.util.concurrent.TimeUnit;
 
@@ -55,16 +50,13 @@ import org.apache.kafka.clients.admin.CreateTopicsResult;
 import org.apache.kafka.clients.admin.NewTopic;
 import org.junit.Rule;
 import org.junit.rules.RuleChain;
-import org.opennms.alec.smoke.containers.BrowserWebDriverContainer;
-import org.opennms.alec.smoke.containers.HelmContainer;
+import org.junit.rules.TestRule;
 import org.opennms.alec.smoke.containers.KafkaContainer;
 import org.opennms.alec.smoke.containers.OpenNMSContainer;
 import org.opennms.alec.smoke.containers.PostgreSQLContainer;
-import org.opennms.alec.smoke.grafana.GrafanaRestClient;
 import org.opennms.alec.smoke.opennms.OpenNMSRestClient;
 import org.opennms.alec.smoke.util.DockerImageResolver;
 import org.opennms.alec.smoke.util.Network;
-import org.openqa.selenium.remote.DesiredCapabilities;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.GenericContainer;
@@ -73,109 +65,76 @@ import org.testcontainers.containers.wait.strategy.Wait;
 
 public abstract class ALECSmokeTestBase {
     private static final Logger LOG = LoggerFactory.getLogger(ALECSmokeTestBase.class);
-    protected static final String PLUGIN_NAME = "opennms-helm-app";
-    protected static final String DATA_SOURCE_NAME = "OpenNMS-Fault-Management";
-    protected static final String DASHBOARD_NAME = "Helm-Dashboard";
-    protected static final String GENERIC_ALARM_TITLE = "Alarm: Generic Trigger";
-    protected GrafanaRestClient grafanaRestClient;
     protected OpenNMSRestClient openNMSRestClient;
 
-    // Define the containers used by all correlation tests
-
+    // Define the containers used by all tests
     protected final GenericContainer kafkaContainer = new KafkaContainer("4.0.0")
             .withNetwork(Network.getNetwork())
             .withNetworkAliases("kafka")
             .waitingFor(new ALECSmokeTestBase.WaitForKafkaTopics());
 
-    protected final GenericContainer postgreSQLContainer = new PostgreSQLContainer(DockerImageResolver.getImageAndTag(
-            "postgres"))
-            .withNetwork(Network.getNetwork())
-            .withNetworkAliases(DB_ALIAS);
-
-    protected final org.testcontainers.containers.BrowserWebDriverContainer webDriverContainer =
-            new BrowserWebDriverContainer(DockerImageResolver.getImageAndTag("selenium"))
-                    .withCapabilities(DesiredCapabilities.chrome())
-                    .withRecordingMode(BrowserWebDriverContainer.VncRecordingMode.RECORD_FAILING,
-                            new File(Optional.ofNullable(System.getenv("TEST_RECORDING_DIR")).orElse("/tmp")));
+    protected final GenericContainer postgreSQLContainer =
+            new PostgreSQLContainer(DockerImageResolver.getImageAndTag(
+                    "postgres"))
+                    .withNetwork(Network.getNetwork())
+                    .withNetworkAliases(DB_ALIAS);
 
     protected final OpenNMSContainer opennmsContainer = new OpenNMSContainer();
 
-    protected final HelmContainer helmContainer = new HelmContainer();
+    // The list of containers to use for tests in startup-order which can be modified by tests through the add/replace
+    // methods in this class
+    private final List<GenericContainer> baseContainers = new ArrayList<>(Arrays.asList(kafkaContainer,
+            postgreSQLContainer, opennmsContainer));
 
-    // The list of containers to use for tests in startup-order
-    private final List<GenericContainer> containers = new ArrayList<>(Arrays.asList(kafkaContainer, postgreSQLContainer,
-            opennmsContainer, helmContainer));
-
-    // Future improvement could be to define a docker compose file and load that rather than individual
-    // containers in a rule chain
     @Rule
-    public RuleChain rc = containerStartupRuleChain();
+    public final RuleChain containerRuleChain = buildContainerStartupRuleChain();
 
-    private RuleChain containerStartupRuleChain() {
+    private RuleChain buildContainerStartupRuleChain() {
+        // Let subclasses change the containers
         adjustContainersForTest();
-        CorrelationSetupAndCleanupRule setupAndCleanup =
-                new CorrelationSetupAndCleanupRule(() -> setup(getOpennmsContainer()), this::cleanup);
-        Iterator<GenericContainer> containerIterator = containers.iterator();
+
+        // Add all the containers to the rule chain
+        Iterator<GenericContainer> containerIterator = baseContainers.iterator();
         RuleChain rc = RuleChain.outerRule(containerIterator.next());
 
         while (containerIterator.hasNext()) {
             rc = rc.around(containerIterator.next());
         }
 
-        // Add the web driver container and the setup/cleanup rules last
-        return rc.around(webDriverContainer).around(setupAndCleanup);
+        // Add setup/cleanup rules
+        return rc.around(new CorrelationSetupAndCleanupRule(this::setup, this::cleanup))
+                .around(setupAndCleanupRule());
     }
 
-    protected abstract void adjustContainersForTest();
-
-    protected void addContainers(List<GenericContainer> containersToAdd) {
-        containers.addAll(Objects.requireNonNull(containersToAdd));
+    protected final void addContainers(List<GenericContainer> containersToAdd) {
+        baseContainers.addAll(Objects.requireNonNull(containersToAdd));
     }
 
-    protected void replaceContainer(GenericContainer existingContainer, GenericContainer newContainer) {
+    protected final void replaceContainer(GenericContainer existingContainer, GenericContainer newContainer) {
         Objects.requireNonNull(existingContainer);
         Objects.requireNonNull(newContainer);
-        containers.set(containers.indexOf(existingContainer), newContainer);
+        baseContainers.set(baseContainers.indexOf(existingContainer), newContainer);
     }
 
-    protected OpenNMSContainer getOpennmsContainer() {
-        return opennmsContainer;
-    }
-
-    private void setupHelm(GrafanaRestClient grafanaRestClient) throws IOException {
-        // Enable Helm plugin
-        grafanaRestClient.setPluginStatus(PLUGIN_NAME, true);
-
-        // Create FM datasource
-        grafanaRestClient.addFMDataSource(DATA_SOURCE_NAME);
-
-        // Create dashboard with alarm table
-        grafanaRestClient.addFMDasboard(DASHBOARD_NAME, DATA_SOURCE_NAME);
-    }
-
-    private void cleanupHelm(GrafanaRestClient grafanaRestClient) {
-        grafanaRestClient.deleteDashboard(DASHBOARD_NAME);
-        grafanaRestClient.deleteDataSource(DATA_SOURCE_NAME);
-        grafanaRestClient.setPluginStatus(PLUGIN_NAME, false);
-    }
-
-    private void setup(OpenNMSContainer openNMSContainer) {
+    private void setup() {
         LOG.info("Setting up...");
-        grafanaRestClient = new GrafanaRestClient(helmContainer.getHelmExternalUrl());
-        openNMSRestClient = new OpenNMSRestClient(openNMSContainer.getOpenNMSUrl());
-        try {
-            setupHelm(grafanaRestClient);
-        } catch (IOException e) {
-            throw new RuntimeException(e);
-        }
-        // No alarms/situations
-        assertThat(openNMSRestClient.getAlarms(), hasSize(0));
+        openNMSRestClient = new OpenNMSRestClient(getOpennmsContainer().getOpenNMSUrl());
     }
 
     private void cleanup() {
         LOG.info("Cleaning up...");
         openNMSRestClient.clearAllAlarms();
-        cleanupHelm(grafanaRestClient);
+    }
+
+    // The following methods are intended to be overridden by sub classes
+    protected abstract void adjustContainersForTest();
+
+    protected TestRule setupAndCleanupRule() {
+        return RuleChain.emptyRuleChain();
+    }
+
+    protected OpenNMSContainer getOpennmsContainer() {
+        return opennmsContainer;
     }
 
     // This ensures the ALEC engine can initialize, without the topics it will wait forever

--- a/smoke-test/src/test/java/org/opennms/alec/smoke/CorrelationSetupAndCleanupRule.java
+++ b/smoke-test/src/test/java/org/opennms/alec/smoke/CorrelationSetupAndCleanupRule.java
@@ -39,7 +39,7 @@ public class CorrelationSetupAndCleanupRule implements TestRule {
     private final Runnable setup;
     private final Runnable cleanup;
 
-    CorrelationSetupAndCleanupRule(Runnable setup, Runnable cleanup) {
+    public CorrelationSetupAndCleanupRule(Runnable setup, Runnable cleanup) {
         this.setup = Objects.requireNonNull(setup);
         this.cleanup = Objects.requireNonNull(cleanup);
     }

--- a/smoke-test/src/test/java/org/opennms/alec/smoke/OnCommitSmokeTest.java
+++ b/smoke-test/src/test/java/org/opennms/alec/smoke/OnCommitSmokeTest.java
@@ -28,6 +28,7 @@
 
 package org.opennms.alec.smoke;
 
+import org.junit.Ignore;
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 import org.opennms.alec.smoke.correlation.DistributedRedundantCorrrelationTest;
@@ -38,5 +39,6 @@ import org.opennms.alec.smoke.correlation.DistributedRedundantCorrrelationTest;
  */
 @RunWith(Suite.class)
 @Suite.SuiteClasses(DistributedRedundantCorrrelationTest.class)
+@Ignore("This test is intended to be invoked explicitly")
 public class OnCommitSmokeTest {
 }

--- a/smoke-test/src/test/java/org/opennms/alec/smoke/OnCommitSmokeTest.java
+++ b/smoke-test/src/test/java/org/opennms/alec/smoke/OnCommitSmokeTest.java
@@ -26,31 +26,17 @@
  *     http://www.opennms.com/
  *******************************************************************************/
 
-package org.opennms.alec.smoke.correlation;
+package org.opennms.alec.smoke;
 
-import java.util.Objects;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+import org.opennms.alec.smoke.correlation.DistributedRedundantCorrrelationTest;
 
-import org.junit.Test;
-import org.opennms.alec.smoke.containers.IntegratedOpenNMSALECContainer;
-import org.opennms.alec.smoke.containers.OpenNMSContainer;
-
-public class IntegratedCorrelationTest extends CorrelationTestBase {
-    private IntegratedOpenNMSALECContainer integratedContainer;
-
-    @Override
-    protected void adjustCorrelationContainers() {
-        // Replace the base opennms container with an integrated one
-        integratedContainer = new IntegratedOpenNMSALECContainer();
-        replaceContainer(opennmsContainer, integratedContainer);
-    }
-
-    @Override
-    protected OpenNMSContainer getOpennmsContainer() {
-        return Objects.requireNonNull(integratedContainer);
-    }
-
-    @Test
-    public void canCorrelateAlarms() throws Exception {
-        runBasicCorrelation();
-    }
+/**
+ * This test suite determines which smoke tests run on-commit in CI. The list of test classes should be kept to a
+ * minimum to reduce the time taken by the commit job, the rest of the smoke tests will run nightly.
+ */
+@RunWith(Suite.class)
+@Suite.SuiteClasses(DistributedRedundantCorrrelationTest.class)
+public class OnCommitSmokeTest {
 }

--- a/smoke-test/src/test/java/org/opennms/alec/smoke/OnCommitSmokeTestSuite.java
+++ b/smoke-test/src/test/java/org/opennms/alec/smoke/OnCommitSmokeTestSuite.java
@@ -28,7 +28,6 @@
 
 package org.opennms.alec.smoke;
 
-import org.junit.Ignore;
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 import org.opennms.alec.smoke.correlation.DistributedRedundantCorrrelationTest;
@@ -39,6 +38,5 @@ import org.opennms.alec.smoke.correlation.DistributedRedundantCorrrelationTest;
  */
 @RunWith(Suite.class)
 @Suite.SuiteClasses(DistributedRedundantCorrrelationTest.class)
-@Ignore("This test is intended to be invoked explicitly")
-public class OnCommitSmokeTest {
+public class OnCommitSmokeTestSuite {
 }

--- a/smoke-test/src/test/java/org/opennms/alec/smoke/containers/OpenNMSContainer.java
+++ b/smoke-test/src/test/java/org/opennms/alec/smoke/containers/OpenNMSContainer.java
@@ -34,6 +34,7 @@ import static org.awaitility.Awaitility.await;
 import static org.hamcrest.Matchers.notNullValue;
 
 import java.io.File;
+import java.net.InetSocketAddress;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.nio.file.Path;
@@ -92,6 +93,10 @@ public class OpenNMSContainer extends GenericContainer {
         } catch (MalformedURLException e) {
             throw new RuntimeException(e);
         }
+    }
+
+    public InetSocketAddress getSSHAddress() {
+        return new InetSocketAddress(getContainerIpAddress(), getMappedPort(OPENNMS_SSH_PORT));
     }
 
     protected Path prepareOverlay() {

--- a/smoke-test/src/test/java/org/opennms/alec/smoke/correlation/CorrelationTestBase.java
+++ b/smoke-test/src/test/java/org/opennms/alec/smoke/correlation/CorrelationTestBase.java
@@ -28,16 +28,60 @@
 
 package org.opennms.alec.smoke.correlation;
 
+import static org.hamcrest.Matchers.hasSize;
+import static org.junit.Assert.assertThat;
+
+import java.io.File;
+import java.io.IOException;
 import java.util.Collections;
+import java.util.Optional;
 
 import org.apache.commons.lang3.tuple.Pair;
+import org.junit.rules.TestRule;
 import org.opennms.alec.smoke.ALECSmokeTestBase;
+import org.opennms.alec.smoke.CorrelationSetupAndCleanupRule;
+import org.opennms.alec.smoke.containers.BrowserWebDriverContainer;
+import org.opennms.alec.smoke.containers.HelmContainer;
 import org.opennms.alec.smoke.grafana.Grafana44SeleniumDriver;
+import org.opennms.alec.smoke.grafana.GrafanaRestClient;
+import org.opennms.alec.smoke.util.DockerImageResolver;
+import org.openqa.selenium.remote.DesiredCapabilities;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public abstract class CorrelationTestBase extends ALECSmokeTestBase {
     private static final Logger LOG = LoggerFactory.getLogger(CorrelationTestBase.class);
+    private static final String PLUGIN_NAME = "opennms-helm-app";
+    private static final String DATA_SOURCE_NAME = "OpenNMS-Fault-Management";
+    private static final String DASHBOARD_NAME = "Helm-Dashboard";
+    private static final String GENERIC_ALARM_TITLE = "Alarm: Generic Trigger";
+    private GrafanaRestClient grafanaRestClient;
+    private HelmContainer helmContainer;
+    private org.testcontainers.containers.BrowserWebDriverContainer webDriverContainer;
+
+    @Override
+    protected final void adjustContainersForTest() {
+        helmContainer = new HelmContainer();
+        webDriverContainer =
+                new BrowserWebDriverContainer(DockerImageResolver.getImageAndTag("selenium"))
+                        .withCapabilities(DesiredCapabilities.chrome())
+                        .withRecordingMode(BrowserWebDriverContainer.VncRecordingMode.RECORD_FAILING,
+                                new File(Optional.ofNullable(System.getenv("TEST_RECORDING_DIR"))
+                                        .orElse("/tmp")));
+
+        addContainers(Collections.singletonList(helmContainer));
+        // Any containers sub classes add will be in between the helm container and web driver container in startup
+        // order
+        adjustCorrelationContainers();
+        addContainers(Collections.singletonList(webDriverContainer));
+    }
+
+    @Override
+    protected final TestRule setupAndCleanupRule() {
+        return new CorrelationSetupAndCleanupRule(this::setup, this::cleanup);
+    }
+
+    protected abstract void adjustCorrelationContainers();
 
     private void verifyGenericSituation() throws Exception {
         new Grafana44SeleniumDriver(webDriverContainer.getWebDriver(),
@@ -48,7 +92,7 @@ public abstract class CorrelationTestBase extends ALECSmokeTestBase {
                 .verifyRelatedAlarmLabels(Collections.singletonList(Pair.of(GENERIC_ALARM_TITLE, 3)));
     }
 
-    protected void runBasicCorrelation() throws Exception {
+    protected final void runBasicCorrelation() throws Exception {
         // Add a node
         LOG.info("Adding node");
         int nodeId = openNMSRestClient.addTestNode();
@@ -64,5 +108,39 @@ public abstract class CorrelationTestBase extends ALECSmokeTestBase {
         // Login, navigate to dashboard, view alarm in table, verify the related alarms
         LOG.info("Situation received, verifying via Helm...");
         verifyGenericSituation();
+    }
+
+    private void setupHelm(GrafanaRestClient grafanaRestClient) throws IOException {
+        // Enable Helm plugin
+        grafanaRestClient.setPluginStatus(PLUGIN_NAME, true);
+
+        // Create FM datasource
+        grafanaRestClient.addFMDataSource(DATA_SOURCE_NAME);
+
+        // Create dashboard with alarm table
+        grafanaRestClient.addFMDasboard(DASHBOARD_NAME, DATA_SOURCE_NAME);
+    }
+
+    private void cleanupHelm(GrafanaRestClient grafanaRestClient) {
+        grafanaRestClient.deleteDashboard(DASHBOARD_NAME);
+        grafanaRestClient.deleteDataSource(DATA_SOURCE_NAME);
+        grafanaRestClient.setPluginStatus(PLUGIN_NAME, false);
+    }
+
+    private void setup() {
+        LOG.info("Setting up...");
+        grafanaRestClient = new GrafanaRestClient(helmContainer.getHelmExternalUrl());
+        try {
+            setupHelm(grafanaRestClient);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+        // No alarms/situations
+        assertThat(openNMSRestClient.getAlarms(), hasSize(0));
+    }
+
+    private void cleanup() {
+        LOG.info("Cleaning up...");
+        cleanupHelm(grafanaRestClient);
     }
 }

--- a/smoke-test/src/test/java/org/opennms/alec/smoke/correlation/DistributedRedundantCorrrelationTest.java
+++ b/smoke-test/src/test/java/org/opennms/alec/smoke/correlation/DistributedRedundantCorrrelationTest.java
@@ -49,7 +49,7 @@ public class DistributedRedundantCorrrelationTest extends CorrelationTestBase {
     private List<ALECSentinelContainer> redundantALECs;
 
     @Override
-    protected void adjustContainersForTest() {
+    protected void adjustCorrelationContainers() {
         redundantALECs = new ArrayList<>();
         // Define NUM_REDUNDANT_ALEC redundant ALECs
         for (int i = 0; i < NUM_REDUNDANT_ALEC; i++) {

--- a/smoke-test/src/test/java/org/opennms/alec/smoke/correlation/DistributedStandaloneCorrelationTest.java
+++ b/smoke-test/src/test/java/org/opennms/alec/smoke/correlation/DistributedStandaloneCorrelationTest.java
@@ -55,7 +55,7 @@ public class DistributedStandaloneCorrelationTest extends CorrelationTestBase {
     }
 
     @Override
-    protected void adjustContainersForTest() {
+    protected void adjustCorrelationContainers() {
         // Define a single non-redundant ALEC
         try {
             alecSentinelContainer = new ALECSentinelContainer(false, () -> engine);

--- a/smoke-test/src/test/java/org/opennms/alec/smoke/udl/DistributedUDLTest.java
+++ b/smoke-test/src/test/java/org/opennms/alec/smoke/udl/DistributedUDLTest.java
@@ -28,21 +28,29 @@
 
 package org.opennms.alec.smoke.udl;
 
+import java.net.InetSocketAddress;
 import java.util.Collections;
 
-import org.junit.Ignore;
 import org.junit.Test;
 import org.opennms.alec.smoke.containers.ALECSentinelContainer;
 
 public class DistributedUDLTest extends UDLTestBase {
+    private ALECSentinelContainer alecSentinelContainer;
+
     @Override
     protected void adjustContainersForTest() {
         // Define a single non-redundant ALEC
         try {
-            addContainers(Collections.singletonList(new ALECSentinelContainer(false, () -> "cluster")));
+            alecSentinelContainer = new ALECSentinelContainer(false, () -> "cluster");
+            addContainers(Collections.singletonList(alecSentinelContainer));
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
+    }
+
+    @Override
+    protected InetSocketAddress getALECContainerSSHAddress() {
+        return alecSentinelContainer.getSSHAddress();
     }
 
     @Test

--- a/smoke-test/src/test/java/org/opennms/alec/smoke/udl/DistributedUDLTest.java
+++ b/smoke-test/src/test/java/org/opennms/alec/smoke/udl/DistributedUDLTest.java
@@ -26,31 +26,27 @@
  *     http://www.opennms.com/
  *******************************************************************************/
 
-package org.opennms.alec.smoke.correlation;
+package org.opennms.alec.smoke.udl;
 
-import java.util.Objects;
+import java.util.Collections;
 
+import org.junit.Ignore;
 import org.junit.Test;
-import org.opennms.alec.smoke.containers.IntegratedOpenNMSALECContainer;
-import org.opennms.alec.smoke.containers.OpenNMSContainer;
+import org.opennms.alec.smoke.containers.ALECSentinelContainer;
 
-public class IntegratedCorrelationTest extends CorrelationTestBase {
-    private IntegratedOpenNMSALECContainer integratedContainer;
-
+public class DistributedUDLTest extends UDLTestBase {
     @Override
-    protected void adjustCorrelationContainers() {
-        // Replace the base opennms container with an integrated one
-        integratedContainer = new IntegratedOpenNMSALECContainer();
-        replaceContainer(opennmsContainer, integratedContainer);
-    }
-
-    @Override
-    protected OpenNMSContainer getOpennmsContainer() {
-        return Objects.requireNonNull(integratedContainer);
+    protected void adjustContainersForTest() {
+        // Define a single non-redundant ALEC
+        try {
+            addContainers(Collections.singletonList(new ALECSentinelContainer(false, () -> "cluster")));
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
     }
 
     @Test
-    public void canCorrelateAlarms() throws Exception {
-        runBasicCorrelation();
+    public void canAddUDL() {
+        testAddingUDL();
     }
 }

--- a/smoke-test/src/test/java/org/opennms/alec/smoke/udl/IntegratedUDLTest.java
+++ b/smoke-test/src/test/java/org/opennms/alec/smoke/udl/IntegratedUDLTest.java
@@ -28,6 +28,7 @@
 
 package org.opennms.alec.smoke.udl;
 
+import java.net.InetSocketAddress;
 import java.util.Objects;
 
 import org.junit.Ignore;
@@ -43,6 +44,11 @@ public class IntegratedUDLTest extends UDLTestBase {
         // Replace the base opennms container with an integrated one
         integratedOpenNMSALECContainer = new IntegratedOpenNMSALECContainer();
         replaceContainer(opennmsContainer, integratedOpenNMSALECContainer);
+    }
+
+    @Override
+    protected InetSocketAddress getALECContainerSSHAddress() {
+        return integratedOpenNMSALECContainer.getSSHAddress();
     }
 
     @Override

--- a/smoke-test/src/test/java/org/opennms/alec/smoke/udl/IntegratedUDLTest.java
+++ b/smoke-test/src/test/java/org/opennms/alec/smoke/udl/IntegratedUDLTest.java
@@ -26,31 +26,32 @@
  *     http://www.opennms.com/
  *******************************************************************************/
 
-package org.opennms.alec.smoke.correlation;
+package org.opennms.alec.smoke.udl;
 
 import java.util.Objects;
 
+import org.junit.Ignore;
 import org.junit.Test;
 import org.opennms.alec.smoke.containers.IntegratedOpenNMSALECContainer;
 import org.opennms.alec.smoke.containers.OpenNMSContainer;
 
-public class IntegratedCorrelationTest extends CorrelationTestBase {
-    private IntegratedOpenNMSALECContainer integratedContainer;
+public class IntegratedUDLTest extends UDLTestBase {
+    private IntegratedOpenNMSALECContainer integratedOpenNMSALECContainer;
 
     @Override
-    protected void adjustCorrelationContainers() {
+    protected void adjustContainersForTest() {
         // Replace the base opennms container with an integrated one
-        integratedContainer = new IntegratedOpenNMSALECContainer();
-        replaceContainer(opennmsContainer, integratedContainer);
+        integratedOpenNMSALECContainer = new IntegratedOpenNMSALECContainer();
+        replaceContainer(opennmsContainer, integratedOpenNMSALECContainer);
     }
 
     @Override
     protected OpenNMSContainer getOpennmsContainer() {
-        return Objects.requireNonNull(integratedContainer);
+        return Objects.requireNonNull(integratedOpenNMSALECContainer);
     }
 
     @Test
-    public void canCorrelateAlarms() throws Exception {
-        runBasicCorrelation();
+    public void canAddUDL() {
+        testAddingUDL();
     }
 }

--- a/smoke-test/src/test/java/org/opennms/alec/smoke/udl/UDLTestBase.java
+++ b/smoke-test/src/test/java/org/opennms/alec/smoke/udl/UDLTestBase.java
@@ -30,25 +30,35 @@ package org.opennms.alec.smoke.udl;
 
 import static org.awaitility.Awaitility.await;
 
+import java.net.InetSocketAddress;
 import java.util.Arrays;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 import org.opennms.alec.smoke.ALECSmokeTestBase;
 import org.opennms.alec.smoke.util.Karaf;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public abstract class UDLTestBase extends ALECSmokeTestBase {
+    private static final Logger LOG = LoggerFactory.getLogger(UDLTestBase.class);
+
+    protected abstract InetSocketAddress getALECContainerSSHAddress();
+    
     protected void testAddingUDL() {
+        LOG.info("Adding test nodes");
         Map<String, Integer> nodeIds = openNMSRestClient.addTestNodes("test1", "test2");
+        LOG.info("Adding user defined link");
         openNMSRestClient.addUDLBetweenNodes(nodeIds.get("test1"), nodeIds.get("test2"));
+        LOG.info("Waiting for ALEC to populate the user defined link");
         // We should see 3 vertices in the ALEC graph, two nodes and one UDL
         await()
                 .atMost(1, TimeUnit.MINUTES)
                 .pollInterval(5, TimeUnit.SECONDS)
                 .ignoreExceptions()
                 .until(() -> {
-                    String[] output = Karaf.runKarafCommands(getOpennmsContainer().getSSHAddress(),
-                            "list-graphs").split("\n");
+                    String[] output = Karaf.runKarafCommands(getALECContainerSSHAddress(),
+                            "opennms-alec:list-graphs").split("\n");
 
                     return Arrays.stream(output).anyMatch(row -> row.contains("3 vertices and 2 edges"));
                 });


### PR DESCRIPTION
This PR adds additional tests for user defined links. It also changes the behaviour of the smoke tests in CI. Now we will only run a subset (1 right now) of the tests on commit and then we run all the tests nightly. This is to reduce the CI time on a per-commit basis.

Verified the tests locally and on circle. To run all the tests the command remains the same:
`mvn test -DsmokeTests=true`

To run just the on-commit tests the command is:
`mvn surefire:test -Dtest=OnCommitSmokeTest -DsmokeTest=true`

Jira: https://issues.opennms.org/browse/ALEC-66