### PR TITLE
ALEC-69: Memory leak in ClusterEngine caused by spatial distance caching

### DIFF
--- a/engine/cluster/src/main/java/org/opennms/alec/engine/cluster/SoftValueDijkstraShortestPath.java
+++ b/engine/cluster/src/main/java/org/opennms/alec/engine/cluster/SoftValueDijkstraShortestPath.java
@@ -1,0 +1,78 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2019 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2019 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.alec.engine.cluster;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.base.Function;
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
+
+import edu.uci.ics.jung.algorithms.shortestpath.DijkstraShortestPath;
+import edu.uci.ics.jung.graph.Graph;
+
+/**
+ * An extension of {@link DijkstraShortestPath} that always caches and uses soft references for the values it caches.
+ * The result is that this implementation will behave as if it is un-cached if the JVM is under memory pressure as the
+ * softly referenced cached values will be evicted.
+ * <p>
+ * Once under memory pressure it is expected that this implementation will perform significantly slower but will not
+ * cause the JVM to run out of memory.
+ */
+public class SoftValueDijkstraShortestPath<V, E> extends DijkstraShortestPath<V, E> {
+    private static final Logger LOG = LoggerFactory.getLogger(SoftValueDijkstraShortestPath.class);
+
+    public SoftValueDijkstraShortestPath(Graph<V, E> g, Function<E, ? extends Number> nev) {
+        super(g, nev, true);
+        initializeMap();
+    }
+
+    @Override
+    public void reset() {
+        initializeMap();
+    }
+
+    @Override
+    public void enableCaching(boolean enable) {
+        throw new UnsupportedOperationException("Caching cannot be controlled for this implementation");
+    }
+
+    private void initializeMap() {
+        Cache<V, SourceData> softValueCache = CacheBuilder.newBuilder()
+                .softValues()
+                .removalListener(notification -> {
+                    if (notification.wasEvicted()) {
+                        LOG.debug("Shortest path data for {} was evicted from the cache", notification.getKey());
+                    }
+                })
+                .build();
+        sourceMap = softValueCache.asMap();
+    }
+}

--- a/engine/dbscan/src/test/java/org/opennms/alec/engine/dbscan/DBScanEnginePerfTest.java
+++ b/engine/dbscan/src/test/java/org/opennms/alec/engine/dbscan/DBScanEnginePerfTest.java
@@ -38,6 +38,7 @@ import java.util.Random;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.IntStream;
 
+import org.junit.Ignore;
 import org.junit.Test;
 import org.opennms.alec.datasource.api.Alarm;
 import org.opennms.alec.datasource.api.InventoryObject;
@@ -90,6 +91,7 @@ public class DBScanEnginePerfTest {
     }
 
     @Test
+    @Ignore("For manual testing")
     public void canNotRunOOM() {
         final DBScanEngine engine = new DBScanEngine();
         engine.init(Collections.emptyList(), Collections.emptyList(), Collections.emptyList(),

--- a/engine/dbscan/src/test/java/org/opennms/alec/engine/dbscan/DBScanEnginePerfTest.java
+++ b/engine/dbscan/src/test/java/org/opennms/alec/engine/dbscan/DBScanEnginePerfTest.java
@@ -28,12 +28,28 @@
 
 package org.opennms.alec.engine.dbscan;
 
+import static org.mockito.Mockito.mock;
+
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.List;
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.IntStream;
 
 import org.junit.Test;
+import org.opennms.alec.datasource.api.Alarm;
+import org.opennms.alec.datasource.api.InventoryObject;
+import org.opennms.alec.datasource.api.Severity;
+import org.opennms.alec.datasource.api.SituationHandler;
 import org.opennms.alec.datasource.common.ImmutableAlarm;
 import org.opennms.alec.datasource.common.ImmutableInventoryObject;
+import org.opennms.alec.driver.test.MockInventoryBuilder;
 import org.opennms.alec.driver.test.MockInventoryType;
+import org.opennms.alec.engine.api.Engine;
+
+import com.google.common.base.Stopwatch;
 
 public class DBScanEnginePerfTest {
 
@@ -70,6 +86,70 @@ public class DBScanEnginePerfTest {
             dbScanEngine.tick(dbScanEngine.getTickResolutionMs() * j);
             long delta = System.currentTimeMillis() - start;
             System.out.printf("%d ms for %d vertices.\n", delta, K);
+        }
+    }
+
+    @Test
+    public void canNotRunOOM() {
+        final DBScanEngine engine = new DBScanEngine();
+        engine.init(Collections.emptyList(), Collections.emptyList(), Collections.emptyList(),
+                Collections.emptyList());
+        engine.registerSituationHandler(mock(SituationHandler.class));
+
+        // With a 1GB heap these values would cause the cluster engine to run OOM before we swapped to using a soft
+        // reference backed implementation of Dijkstra's algorithm after ~50 seconds
+        //
+        // With the new impl this test passes after ~50 seconds
+        int numVertices = 3000;
+        int numAlarmsToAddPerIteration = 100;
+
+        // Create inventory for numVertices
+        MockInventoryBuilder mockInventoryBuilder = new MockInventoryBuilder();
+        List<Integer> existingInventoryIds = new ArrayList<>();
+
+        // Add a root inventory element
+        existingInventoryIds.add(0);
+        mockInventoryBuilder.withInventoryObject(MockInventoryType.COMPONENT, "0");
+
+        Random random = new Random(1);
+        // Add the rest of the inventory
+        for (int i = 1; i < numVertices; i++) {
+            int parent = existingInventoryIds.get(random.nextInt(existingInventoryIds.size()));
+            mockInventoryBuilder.withInventoryObject(MockInventoryType.COMPONENT, Integer.toString(i),
+                    MockInventoryType.COMPONENT, Integer.toString(parent));
+            existingInventoryIds.add(i);
+        }
+
+        // Add the inventory to the engine
+        Collection<InventoryObject> inventory = mockInventoryBuilder.getInventory();
+        engine.onInventoryAdded(inventory);
+
+        long tickTime = System.currentTimeMillis();
+        long tickInterval = TimeUnit.MINUTES.toMillis(6);
+
+        int alarmedVertex = 0;
+        while (alarmedVertex < numVertices) {
+            List<Alarm> alarmsAdded = new ArrayList<>();
+            for (int i = 0; i < numAlarmsToAddPerIteration; i++) {
+                int id = existingInventoryIds.get(alarmedVertex++);
+                Alarm alarmToAdd = ImmutableAlarm.newBuilder()
+                        .setInventoryObjectType(MockInventoryType.COMPONENT.getType())
+                        .setInventoryObjectId(Integer.toString(id))
+                        .setId("test.id." + Integer.toString(id))
+                        .setTime(tickTime)
+                        .build();
+                alarmsAdded.add(alarmToAdd);
+                engine.onAlarmCreatedOrUpdated(alarmToAdd);
+            }
+
+            engine.onTick(tickTime);
+
+            // Clear the alarms we just added and tick by a big enough interval that they are GC'd so we end up with a
+            // fresh set of alarms on the next iteration
+            alarmsAdded.forEach(alarm -> engine.onAlarmCleared(ImmutableAlarm.newBuilderFrom(alarm)
+                    .setSeverity(Severity.CLEARED)
+                    .build()));
+            tickTime += tickInterval;
         }
     }
 }


### PR DESCRIPTION
- Fixed memory leak in ALEC for large graphs that change infrequently
- Also improved the efficiency of getting the vertex Id a given alarm is associated with

Jira: https://issues.opennms.org/browse/ALEC-69