### PR TITLE
Fix for failed smoke tests due to missing docker tag

### DIFF
--- a/smoke-test/src/main/resources/docker_fixed_images
+++ b/smoke-test/src/main/resources/docker_fixed_images
@@ -7,3 +7,5 @@ kafka=confluentinc/cp-kafka:4.0.0
 postgres=postgres:10.7-alpine
 # Note this tag version should match the selenium version in the POM
 selenium=selenium/standalone-chrome-debug:3.4.0
+sentinel=opennms/sentinel:24.1.1-1
+opennms=opennms/horizon-core-web:24.1.0-1

--- a/smoke-test/src/main/resources/docker_floating_images
+++ b/smoke-test/src/main/resources/docker_floating_images
@@ -1,5 +1,2 @@
 # Use this file for docker images/tags that are subject to change and shouldn't be cached to ensure we always use the
 # latest image they provide
-
-sentinel=opennms/sentinel:24.0.0-rc
-opennms=opennms/horizon-core-web:24.0.0-rc


### PR DESCRIPTION
Updated the docker tags for OpenNMS and Sentinel to fixed 24.x versions to fix failing smoke tests.

No Jira.