### PR TITLE
ALEC-75: Upgrade Alec Kafka Components to 2.2.0 on Scala 2.12

### DIFF
--- a/datasource/opennms-kafka/pom.xml
+++ b/datasource/opennms-kafka/pom.xml
@@ -36,11 +36,12 @@
         </plugins>
     </build>
 
-    <properties>
-        <kafka.version>2.0.0</kafka.version>
-        <kafka.bundle.version>2.0.0_1</kafka.bundle.version>
+    <!-- <properties>
+        <kafka.scala.version>2.12</kafka.scala.version>
+        <kafka.version>2.2.0</kafka.version>
+        <kafka.bundle.version>2.2.0_1</kafka.bundle.version>
         <spring.kafka.version>2.2.0.RELEASE</spring.kafka.version>
-    </properties>
+    </properties> -->
 
     <dependencies>
         <dependency>
@@ -163,13 +164,13 @@
         </dependency>
         <dependency>
             <groupId>org.apache.kafka</groupId>
-            <artifactId>kafka_2.11</artifactId>
+            <artifactId>kafka_${kafka.scala.version}</artifactId>
             <version>${kafka.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.kafka</groupId>
-            <artifactId>kafka_2.11</artifactId>
+            <artifactId>kafka_${kafka.scala.version}</artifactId>
             <version>${kafka.version}</version>
             <classifier>test</classifier>
             <scope>test</scope>

--- a/datasource/opennms-kafka/pom.xml
+++ b/datasource/opennms-kafka/pom.xml
@@ -36,13 +36,6 @@
         </plugins>
     </build>
 
-    <!-- <properties>
-        <kafka.scala.version>2.12</kafka.scala.version>
-        <kafka.version>2.2.0</kafka.version>
-        <kafka.bundle.version>2.2.0_1</kafka.bundle.version>
-        <spring.kafka.version>2.2.0.RELEASE</spring.kafka.version>
-    </properties> -->
-
     <dependencies>
         <dependency>
             <groupId>org.opennms.alec.datasource</groupId>

--- a/features/graph/rest/pom.xml
+++ b/features/graph/rest/pom.xml
@@ -46,7 +46,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
-            <version>${jackson.version}</version>
+            <version>${jackson-annotations.version}</version>
         </dependency>
 
         <!-- Test -->

--- a/karaf-features/src/main/resources/features.xml
+++ b/karaf-features/src/main/resources/features.xml
@@ -235,26 +235,26 @@
 
     <!-- Generic dependencies -->
 
-    <feature name="rocksdb" version="5.7.3">
-        <bundle>wrap:mvn:org.rocksdb/rocksdbjni/5.7.3$Export-Package=org.rocksdb;version=5.7.3,org.rocksdb.util;version=5.7.3</bundle>
+    <feature name="rocksdb" version="${rocksdb.version}">
+        <bundle>wrap:mvn:org.rocksdb/rocksdbjni/${rocksdb.version}$Export-Package=org.rocksdb;version=${rocksdb.version},org.rocksdb.util;version=${rocksdb.version}</bundle>
     </feature>
 
     <feature name="kafka-streams" description="Kafka Streams" version="${kafka.version}">
-        <feature version="5.7.3" dependency="true">rocksdb</feature>
+        <feature version="${rocksdb.version}" dependency="true">rocksdb</feature>
         <bundle dependency="true">mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.kafka-streams/${kafka.bundle.version}</bundle>
         <bundle dependency="true">mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.kafka-clients/${kafka.bundle.version}</bundle>
-        <bundle dependency="true">mvn:org.lz4/lz4-java/1.4.1</bundle>
-        <bundle dependency="true">wrap:mvn:org.xerial.snappy/snappy-java/1.1.7.1</bundle>
+        <bundle dependency="true">mvn:org.lz4/lz4-java/${lz4.version}</bundle>
+        <bundle dependency="true">wrap:mvn:org.xerial.snappy/snappy-java/${snappy-java.version}</bundle>
         <bundle dependency="true">wrap:mvn:org.apache.kafka/connect-json/${kafka.version}</bundle>
         <bundle dependency="true">wrap:mvn:org.apache.kafka/connect-api/${kafka.version}</bundle>
-        <bundle dependency="true">mvn:com.fasterxml.jackson.core/jackson-databind/2.9.6</bundle>
-        <bundle dependency="true">mvn:com.fasterxml.jackson.core/jackson-annotations/2.9.0</bundle>
-        <bundle dependency="true">mvn:com.fasterxml.jackson.core/jackson-core/2.9.6</bundle>
+        <bundle dependency="true">mvn:com.fasterxml.jackson.core/jackson-databind/${jackson.version}</bundle>
+        <bundle dependency="true">mvn:com.fasterxml.jackson.core/jackson-annotations/${jackson-annotations.version}</bundle>
+        <bundle dependency="true">mvn:com.fasterxml.jackson.core/jackson-core/${jackson.version}</bundle>
     </feature>
 
     <feature name="commons-text" description="commons-text" version="${commons.text.version}">
         <bundle>mvn:org.apache.commons/commons-text/${commons.text.version}</bundle>
-        <bundle dependency="true">mvn:org.apache.commons/commons-lang3/3.7</bundle>
+        <bundle dependency="true">mvn:org.apache.commons/commons-lang3/${commons.lang3.version}</bundle>
     </feature>
 
     <feature name="javax.mail" description="javax.mail" version="1.4.5">
@@ -272,7 +272,7 @@
     <feature name="jackson-jaxrs" description="Jackson :: JAXRS :: JSON Provider" version="${jackson.version}">
         <feature dependency="true" version="${cxf.version}">cxf-jaxrs</feature>
         <bundle>mvn:com.fasterxml.jackson.core/jackson-databind/${jackson.version}</bundle>
-        <bundle >mvn:com.fasterxml.jackson.core/jackson-annotations/${jackson.version}</bundle>
+        <bundle>mvn:com.fasterxml.jackson.core/jackson-annotations/${jackson-annotations.version}</bundle>
         <bundle>mvn:com.fasterxml.jackson.core/jackson-core/${jackson.version}</bundle>
         <bundle>mvn:com.fasterxml.jackson.jaxrs/jackson-jaxrs-base/${jackson.version}</bundle>
         <bundle>mvn:com.fasterxml.jackson.jaxrs/jackson-jaxrs-json-provider/${jackson.version}</bundle>

--- a/karaf-features/src/main/resources/features.xml
+++ b/karaf-features/src/main/resources/features.xml
@@ -31,7 +31,7 @@
     <feature name="alec-datasource-opennms-kafka" description="ALEC :: Datasource :: OpenNMS Kafka" version="${project.version}">
         <feature version="${project.version}">alec-datasource-api</feature>
         <bundle>mvn:org.opennms.alec.datasource/org.opennms.alec.datasource.opennms-kafka/${project.version}</bundle>
-        <feature version="2.0.0">kafka-streams</feature>
+        <feature version="${kafka.version}">kafka-streams</feature>
         <feature version="${project.version}">alec-integrations-opennms-sink</feature>
         <bundle dependency="true">mvn:com.google.guava/guava/${guava.version}</bundle>
         <bundle dependency="true">mvn:com.google.protobuf/protobuf-java/${protobuf.version}</bundle>
@@ -239,14 +239,14 @@
         <bundle>wrap:mvn:org.rocksdb/rocksdbjni/5.7.3$Export-Package=org.rocksdb;version=5.7.3,org.rocksdb.util;version=5.7.3</bundle>
     </feature>
 
-    <feature name="kafka-streams" description="Kafka Streams" version="2.0.0">
+    <feature name="kafka-streams" description="Kafka Streams" version="${kafka.version}">
         <feature version="5.7.3" dependency="true">rocksdb</feature>
-        <bundle dependency="true">mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.kafka-streams/2.0.0_1</bundle>
-        <bundle dependency="true">mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.kafka-clients/2.0.0_1</bundle>
+        <bundle dependency="true">mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.kafka-streams/${kafka.bundle.version}</bundle>
+        <bundle dependency="true">mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.kafka-clients/${kafka.bundle.version}</bundle>
         <bundle dependency="true">mvn:org.lz4/lz4-java/1.4.1</bundle>
         <bundle dependency="true">wrap:mvn:org.xerial.snappy/snappy-java/1.1.7.1</bundle>
-        <bundle dependency="true">wrap:mvn:org.apache.kafka/connect-json/2.0.0</bundle>
-        <bundle dependency="true">wrap:mvn:org.apache.kafka/connect-api/2.0.0</bundle>
+        <bundle dependency="true">wrap:mvn:org.apache.kafka/connect-json/${kafka.version}</bundle>
+        <bundle dependency="true">wrap:mvn:org.apache.kafka/connect-api/${kafka.version}</bundle>
         <bundle dependency="true">mvn:com.fasterxml.jackson.core/jackson-databind/2.9.6</bundle>
         <bundle dependency="true">mvn:com.fasterxml.jackson.core/jackson-annotations/2.9.0</bundle>
         <bundle dependency="true">mvn:com.fasterxml.jackson.core/jackson-core/2.9.6</bundle>

--- a/pom.xml
+++ b/pom.xml
@@ -49,6 +49,7 @@
         <awaitility.version>3.1.1</awaitility.version>
         <commons.csv.version>1.5</commons.csv.version>
         <commons.io.version>2.6</commons.io.version>
+        <commons.lang3.version>3.7</commons.lang3.version>
         <commons.math.version>3.6.1</commons.math.version>
         <commons.text.version>1.3</commons.text.version>
         <cxf.version>3.2.6</cxf.version>
@@ -58,11 +59,16 @@
         <gson.version>2.8.2</gson.version>
         <hamcrest.version>1.3</hamcrest.version>
         <java.version>1.8</java.version>
-        <jackson.version>2.9.7</jackson.version>
+        <jackson.version>2.9.8</jackson.version>
+        <jackson-annotations.version>2.9.0</jackson-annotations.version>
         <jung.version>2.1.1</jung.version>
         <junit.version>4.12</junit.version>
+        <kafka.bundle.version>2.2.0_1</kafka.bundle.version>
+        <kafka.scala.version>2.12</kafka.scala.version>
+        <kafka.version>2.2.0</kafka.version>
         <karaf.version>4.2.3</karaf.version>
         <log4j.version>2.8.2</log4j.version>
+        <lz4.version>1.5.0</lz4.version>
         <metrics.version>4.1.0</metrics.version>
         <mockito.version>2.18.0</mockito.version>
         <moxy.version>2.7.3</moxy.version>
@@ -74,14 +80,13 @@
         <osgi.version>6.0.0</osgi.version>
         <osgi.compendium.version>5.0.0</osgi.compendium.version>
         <protobuf.version>3.5.1</protobuf.version>
+        <rocksdb.version>5.15.10</rocksdb.version>
         <slf4j-api.version>1.7.25</slf4j-api.version>
+        <snappy-java.version>1.1.7.2</snappy-java.version>
         <snmp4j.bundle.version>2.6.3_1</snmp4j.bundle.version>
+        <spring.kafka.version>2.2.7.RELEASE</spring.kafka.version>
         <string.similarity.version>1.1.0</string.similarity.version>
         <tensorflow.version>1.13.1</tensorflow.version>
-        <kafka.scala.version>2.12</kafka.scala.version>
-        <kafka.version>2.2.0</kafka.version>
-        <kafka.bundle.version>2.2.0_1</kafka.bundle.version>
-        <spring.kafka.version>2.2.0.RELEASE</spring.kafka.version>
     </properties>
 
     <dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -78,6 +78,10 @@
         <snmp4j.bundle.version>2.6.3_1</snmp4j.bundle.version>
         <string.similarity.version>1.1.0</string.similarity.version>
         <tensorflow.version>1.13.1</tensorflow.version>
+        <kafka.scala.version>2.12</kafka.scala.version>
+        <kafka.version>2.2.0</kafka.version>
+        <kafka.bundle.version>2.2.0_1</kafka.bundle.version>
+        <spring.kafka.version>2.2.0.RELEASE</spring.kafka.version>
     </properties>
 
     <dependencyManagement>

--- a/smoke-test/pom.xml
+++ b/smoke-test/pom.xml
@@ -14,10 +14,9 @@
     <properties>
         <jcraft.version>0.1.51</jcraft.version>
         <jersey.version>2.28</jersey.version>
-        <selenium.version>3.4.0</selenium.version>
+        <selenium.version>3.6.0</selenium.version>
         <!--This module needs a newer version of guava than the root pom version -->
         <guava.version>28.0-jre</guava.version>
-        <commonsLang3Version>3.4</commonsLang3Version>
         <testContainersVersion>1.11.3</testContainersVersion>
     </properties>
     <build>
@@ -167,7 +166,12 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
-            <version>${commonsLang3Version}</version>
+            <version>${commons.lang3.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+            <version>2.5</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>


### PR DESCRIPTION
ALEC-75: Upgrade Alec Kafka Components to 2.2.0 on Scala 1.12
ALEC-75: Cleanup opennms-kafka pom
ALEC-75: Update/Centralize dependency versions to reduce conflicts

### External References

* JIRA (Issue Tracker): https://issues.opennms.org/browse/ALEC-75