### PR TITLE
Expose additional metrics via JMX

### DIFF
--- a/driver/main/pom.xml
+++ b/driver/main/pom.xml
@@ -46,10 +46,6 @@
         </dependency>
         <dependency>
             <groupId>io.dropwizard.metrics</groupId>
-            <artifactId>metrics-core</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.dropwizard.metrics</groupId>
             <artifactId>metrics-jmx</artifactId>
         </dependency>
 

--- a/driver/main/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/driver/main/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -12,20 +12,6 @@
     <!-- Situation Processor -->
     <reference id="situationProcessorFactory" interface="org.opennms.alec.processor.api.SituationProcessorFactory"/>
 
-    <!-- Metrics -->
-    <bean id="metricRegistry" class="com.codahale.metrics.MetricRegistry"/>
-    <bean id="metricRegistryJmxReporterBuilder" class="com.codahale.metrics.jmx.JmxReporter" factory-method="forRegistry">
-        <argument ref="metricRegistry"/>
-    </bean>
-    <bean id="metricRegistryDomainedJmxReporterBuilder" factory-ref="metricRegistryJmxReporterBuilder" factory-method="inDomain">
-        <argument value="org.opennms.alec.driver.main"/>
-    </bean>
-    <bean id="metricRegistryJmxReporter"
-          factory-ref="metricRegistryDomainedJmxReporterBuilder"
-          factory-method="build"
-          init-method="start"
-          destroy-method="stop" />
-
     <bean id="driver" class="org.opennms.alec.driver.main.Driver" init-method="init" destroy-method="destroy">
         <argument ref="blueprintBundleContext"/>
         <argument ref="alarmDatasource"/>
@@ -34,7 +20,6 @@
         <argument ref="situationDatasource"/>
         <argument ref="engineFactory"/>
         <argument ref="situationProcessorFactory"/>
-        <argument ref="metricRegistry"/>
     </bean>
     <service ref="driver" interface="org.opennms.alec.engine.api.EngineRegistry"/>
 

--- a/driver/main/src/test/java/org/opennms/alec/driver/main/DriverTest.java
+++ b/driver/main/src/test/java/org/opennms/alec/driver/main/DriverTest.java
@@ -31,6 +31,7 @@ package org.opennms.alec.driver.main;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.hasSize;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -62,12 +63,11 @@ public class DriverTest {
         SituationProcessorFactory situationProcessorFactory = mock(SituationProcessorFactory.class);
         when(situationProcessorFactory.getInstance()).thenReturn(mock(SituationProcessor.class));
         TickLoggingEngine tickLoggingEngine = new TickLoggingEngine();
-        when(engineFactory.createEngine()).thenReturn(tickLoggingEngine);
-        MetricRegistry metrics = new MetricRegistry();
+        when(engineFactory.createEngine(any(MetricRegistry.class))).thenReturn(tickLoggingEngine);
 
         // Create and initialize the driver
         Driver driver = new Driver(bundleContext, alarmDatasource, alarmFeedbackDatasource, inventoryDatasource,
-                situationDatasource, engineFactory, situationProcessorFactory, metrics);
+                situationDatasource, engineFactory, situationProcessorFactory);
         driver.initAsync().get();
 
         // Tick tock

--- a/driver/test/src/main/java/org/opennms/alec/driver/test/TestDriver.java
+++ b/driver/test/src/main/java/org/opennms/alec/driver/test/TestDriver.java
@@ -59,6 +59,8 @@ import org.opennms.alec.features.graph.common.GraphMLConverterBuilder;
 import org.opennms.alec.features.graph.graphml.GraphML;
 import org.opennms.alec.features.graph.graphml.GraphMLWriter;
 
+import com.codahale.metrics.MetricRegistry;
+
 public class TestDriver {
     private final EngineFactory engineFactory;
     private boolean verbose = false;
@@ -147,7 +149,7 @@ public class TestDriver {
     private List<Situation> run(List<Alarm> alarms, List<InventoryObject> inventory, List<Alarm> previousAlarms,
                                 List<AlarmFeedback> previousAlarmFeedback, List<Situation> previousSituations) {
         final DriverSession session = new DriverSession();
-        final Engine engine = engineFactory.createEngine();
+        final Engine engine = engineFactory.createEngine(new MetricRegistry());
         engine.registerSituationHandler(session);
         engine.init(previousAlarms, previousAlarmFeedback, previousSituations, inventory);
 

--- a/engine/api/pom.xml
+++ b/engine/api/pom.xml
@@ -15,5 +15,9 @@
             <groupId>org.opennms.alec.datasource</groupId>
             <artifactId>org.opennms.alec.datasource.api</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.dropwizard.metrics</groupId>
+            <artifactId>metrics-core</artifactId>
+        </dependency>
     </dependencies>
 </project>

--- a/engine/api/src/main/java/org/opennms/alec/engine/api/EngineFactory.java
+++ b/engine/api/src/main/java/org/opennms/alec/engine/api/EngineFactory.java
@@ -28,10 +28,12 @@
 
 package org.opennms.alec.engine.api;
 
+import com.codahale.metrics.MetricRegistry;
+
 public interface EngineFactory {
 
     String getName();
 
-    Engine createEngine();
+    Engine createEngine(MetricRegistry metrics);
 
 }

--- a/engine/cluster/src/main/java/org/opennms/alec/engine/cluster/AbstractClusterEngine.java
+++ b/engine/cluster/src/main/java/org/opennms/alec/engine/cluster/AbstractClusterEngine.java
@@ -161,7 +161,7 @@ public abstract class AbstractClusterEngine implements Engine, GraphProvider, Sp
     }
 
     @Override
-    public void init(List<Alarm> alarms, List<AlarmFeedback> alarmFeedback, List<Situation> situations,
+    public synchronized void init(List<Alarm> alarms, List<AlarmFeedback> alarmFeedback, List<Situation> situations,
                      List<InventoryObject> inventory) {
         try {
             LOG.debug("Initialized with {} alarms, {} alarm feedback, {} situations and {} inventory objects.",

--- a/engine/cluster/src/main/java/org/opennms/alec/engine/cluster/ClusterEngine.java
+++ b/engine/cluster/src/main/java/org/opennms/alec/engine/cluster/ClusterEngine.java
@@ -34,12 +34,18 @@ import java.util.List;
 import org.apache.commons.math3.ml.clustering.Cluster;
 import org.opennms.alec.datasource.api.Alarm;
 
+import com.codahale.metrics.MetricRegistry;
+
 import edu.uci.ics.jung.graph.Graph;
 
 /**
  * Simple cluster engine implementation
  */
 public class ClusterEngine extends AbstractClusterEngine {
+
+    public ClusterEngine(MetricRegistry metrics) {
+        super(metrics);
+    }
 
     /**
      * Use the graph structure to build clusters:

--- a/engine/cluster/src/main/java/org/opennms/alec/engine/cluster/ClusterEngineFactory.java
+++ b/engine/cluster/src/main/java/org/opennms/alec/engine/cluster/ClusterEngineFactory.java
@@ -30,6 +30,9 @@ package org.opennms.alec.engine.cluster;
 
 import org.opennms.alec.engine.api.EngineFactory;
 
+import com.codahale.metrics.MetricRegistry;
+
+
 public class ClusterEngineFactory implements EngineFactory {
 
     @Override
@@ -38,8 +41,8 @@ public class ClusterEngineFactory implements EngineFactory {
     }
 
     @Override
-    public AbstractClusterEngine createEngine() {
-        return new ClusterEngine();
+    public AbstractClusterEngine createEngine(MetricRegistry metrics) {
+        return new ClusterEngine(metrics);
     }
 
 }

--- a/engine/cluster/src/main/java/org/opennms/alec/engine/cluster/GraphManager.java
+++ b/engine/cluster/src/main/java/org/opennms/alec/engine/cluster/GraphManager.java
@@ -315,6 +315,10 @@ public class GraphManager {
         consumer.accept(g, resourceKeyVertexMap.get(ResourceKey.key(type, id)));
     }
 
+    public int getVertexCount() {
+        return g.getVertexCount();
+    }
+
     protected Graph<CEVertex, CEEdge> getGraph() {
         return g;
     }

--- a/engine/cluster/src/test/java/org/opennms/alec/engine/cluster/ClusterEngineSituationTest.java
+++ b/engine/cluster/src/test/java/org/opennms/alec/engine/cluster/ClusterEngineSituationTest.java
@@ -46,6 +46,7 @@ import org.opennms.alec.datasource.api.SituationHandler;
 import org.opennms.alec.datasource.common.ImmutableAlarm;
 import org.opennms.alec.datasource.common.ImmutableSituation;
 
+import com.codahale.metrics.MetricRegistry;
 import com.google.common.collect.Iterables;
 
 public class ClusterEngineSituationTest implements SituationHandler {
@@ -73,7 +74,7 @@ public class ClusterEngineSituationTest implements SituationHandler {
         // No situations should have been triggered yet
         assertThat(triggeredSituations, hasSize(0));
 
-        ClusterEngine clusterEngine = new ClusterEngine();
+        ClusterEngine clusterEngine = new ClusterEngine(new MetricRegistry());
         clusterEngine.init(alarms, Collections.emptyList(), Collections.emptyList(), Collections.emptyList());
         clusterEngine.registerSituationHandler(this);
         clusterEngine.tick(clusterEngine.getTickResolutionMs());
@@ -92,7 +93,7 @@ public class ClusterEngineSituationTest implements SituationHandler {
                 .setAlarms(new HashSet<>(Arrays.asList(a1, a2)))
                 .build();
 
-        clusterEngine = new ClusterEngine();
+        clusterEngine = new ClusterEngine(new MetricRegistry());
         clusterEngine.init(alarms, Collections.emptyList(), Collections.singletonList(initialSituation),
                 Collections.emptyList());
         clusterEngine.registerSituationHandler(this);
@@ -114,7 +115,7 @@ public class ClusterEngineSituationTest implements SituationHandler {
                 .setInventoryObjectType("node")
                 .setTime(10000L)
                 .build(), a2, a3);
-        clusterEngine = new ClusterEngine();
+        clusterEngine = new ClusterEngine(new MetricRegistry());
         clusterEngine.init(alarms, Collections.emptyList(), Collections.singletonList(initialSituation), Collections.emptyList());
         clusterEngine.registerSituationHandler(this);
         clusterEngine.tick(clusterEngine.getTickResolutionMs());

--- a/engine/cluster/src/test/java/org/opennms/alec/engine/cluster/ClusterEngineTest.java
+++ b/engine/cluster/src/test/java/org/opennms/alec/engine/cluster/ClusterEngineTest.java
@@ -63,13 +63,14 @@ import org.opennms.alec.datasource.common.ImmutableSituation;
 import org.opennms.alec.driver.test.MockInventoryBuilder;
 import org.opennms.alec.driver.test.MockInventoryType;
 
+import com.codahale.metrics.MetricRegistry;
 import com.google.common.collect.Iterables;
 
 import edu.uci.ics.jung.graph.Graph;
 
 public class ClusterEngineTest implements SituationHandler {
 
-    private ClusterEngine engine = new ClusterEngine();
+    private ClusterEngine engine = new ClusterEngine(new MetricRegistry());
 
     private Map<String, Situation> situationsById = new LinkedHashMap<>();
 

--- a/engine/dbscan/src/main/java/org/opennms/alec/engine/dbscan/DBScanEngine.java
+++ b/engine/dbscan/src/main/java/org/opennms/alec/engine/dbscan/DBScanEngine.java
@@ -42,6 +42,8 @@ import org.opennms.alec.engine.cluster.CEVertex;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.codahale.metrics.MetricRegistry;
+
 import edu.uci.ics.jung.graph.Graph;
 
 /**
@@ -74,11 +76,12 @@ public class DBScanEngine extends AbstractClusterEngine {
     private final double epsilon;
     private final AlarmInSpaceTimeDistanceMeasure distanceMeasure;
 
-    public DBScanEngine() {
-        this(DEFAULT_EPSILON, DEFAULT_ALPHA, DEFAULT_BETA);
+    public DBScanEngine(MetricRegistry metrics) {
+        this(metrics, DEFAULT_EPSILON, DEFAULT_ALPHA, DEFAULT_BETA);
     }
 
-    public DBScanEngine(double epsilon, double alpha, double beta) {
+    public DBScanEngine(MetricRegistry metrics, double epsilon, double alpha, double beta) {
+        super(metrics);
         this.epsilon = epsilon;
         distanceMeasure = new AlarmInSpaceTimeDistanceMeasure(this, alpha, beta);
     }

--- a/engine/dbscan/src/main/java/org/opennms/alec/engine/dbscan/DBScanEngineFactory.java
+++ b/engine/dbscan/src/main/java/org/opennms/alec/engine/dbscan/DBScanEngineFactory.java
@@ -31,6 +31,8 @@ package org.opennms.alec.engine.dbscan;
 import org.opennms.alec.engine.api.EngineFactory;
 import org.opennms.alec.engine.cluster.AbstractClusterEngine;
 
+import com.codahale.metrics.MetricRegistry;
+
 public class DBScanEngineFactory implements EngineFactory {
 
     private double epsilon = DBScanEngine.DEFAULT_EPSILON;
@@ -43,8 +45,8 @@ public class DBScanEngineFactory implements EngineFactory {
     }
 
     @Override
-    public AbstractClusterEngine createEngine() {
-        return new DBScanEngine(epsilon, alpha, beta);
+    public AbstractClusterEngine createEngine(MetricRegistry metrics) {
+        return new DBScanEngine(metrics, epsilon, alpha, beta);
     }
 
     public double getEpsilon() {

--- a/engine/dbscan/src/test/java/org/opennms/alec/engine/dbscan/DBScanEnginePerfTest.java
+++ b/engine/dbscan/src/test/java/org/opennms/alec/engine/dbscan/DBScanEnginePerfTest.java
@@ -50,6 +50,7 @@ import org.opennms.alec.driver.test.MockInventoryBuilder;
 import org.opennms.alec.driver.test.MockInventoryType;
 import org.opennms.alec.engine.api.Engine;
 
+import com.codahale.metrics.MetricRegistry;
 import com.google.common.base.Stopwatch;
 
 public class DBScanEnginePerfTest {
@@ -61,7 +62,7 @@ public class DBScanEnginePerfTest {
      */
     @Test
     public void canRunDBScanOnLargeGraphs() {
-        final DBScanEngine dbScanEngine = new DBScanEngine();
+        final DBScanEngine dbScanEngine = new DBScanEngine(new MetricRegistry());
         dbScanEngine.init(Collections.emptyList(), Collections.emptyList(), Collections.emptyList(),
                 Collections.emptyList());
         final int K = 500;
@@ -93,7 +94,7 @@ public class DBScanEnginePerfTest {
     @Test
     @Ignore("For manual testing")
     public void canNotRunOOM() {
-        final DBScanEngine engine = new DBScanEngine();
+        final DBScanEngine engine = new DBScanEngine(new MetricRegistry());
         engine.init(Collections.emptyList(), Collections.emptyList(), Collections.emptyList(),
                 Collections.emptyList());
         engine.registerSituationHandler(mock(SituationHandler.class));

--- a/engine/deeplearning/src/main/java/org/opennms/alec/engine/deeplearning/DeepLearningEngine.java
+++ b/engine/deeplearning/src/main/java/org/opennms/alec/engine/deeplearning/DeepLearningEngine.java
@@ -38,6 +38,8 @@ import org.opennms.alec.engine.cluster.CEEdge;
 import org.opennms.alec.engine.cluster.CEVertex;
 import org.osgi.framework.BundleContext;
 
+import com.codahale.metrics.MetricRegistry;
+
 import edu.uci.ics.jung.graph.Graph;
 
 /**
@@ -52,11 +54,12 @@ public class DeepLearningEngine extends AbstractClusterEngine {
     private Vectorizer vectorizer;
     private TFClusterer tfClusterer;
 
-    public DeepLearningEngine(BundleContext bundleContext, DeepLearningEngineConf conf) {
-        this(new TFModel(bundleContext, conf.getModelPath()), conf);
+    public DeepLearningEngine(MetricRegistry metrics, BundleContext bundleContext, DeepLearningEngineConf conf) {
+        this(metrics, new TFModel(bundleContext, conf.getModelPath()), conf);
     }
 
-    private DeepLearningEngine(TFModel tfModel, DeepLearningEngineConf conf) {
+    private DeepLearningEngine(MetricRegistry metrics, TFModel tfModel, DeepLearningEngineConf conf) {
+        super(metrics);
         this.tfModel = Objects.requireNonNull(tfModel);
         this.conf = Objects.requireNonNull(conf);
     }

--- a/engine/deeplearning/src/main/java/org/opennms/alec/engine/deeplearning/DeepLearningEngineFactory.java
+++ b/engine/deeplearning/src/main/java/org/opennms/alec/engine/deeplearning/DeepLearningEngineFactory.java
@@ -33,6 +33,8 @@ import java.util.Objects;
 import org.opennms.alec.engine.api.EngineFactory;
 import org.osgi.framework.BundleContext;
 
+import com.codahale.metrics.MetricRegistry;
+
 public class DeepLearningEngineFactory implements EngineFactory {
 
     private final BundleContext bundleContext;
@@ -54,8 +56,8 @@ public class DeepLearningEngineFactory implements EngineFactory {
     }
 
     @Override
-    public DeepLearningEngine createEngine() {
-        return new DeepLearningEngine(bundleContext, conf);
+    public DeepLearningEngine createEngine(MetricRegistry metrics) {
+        return new DeepLearningEngine(metrics, bundleContext, conf);
     }
 
 }

--- a/engine/itest/src/test/java/org/opennms/alec/engine/itest/Level1EngineComplianceTest.java
+++ b/engine/itest/src/test/java/org/opennms/alec/engine/itest/Level1EngineComplianceTest.java
@@ -66,6 +66,7 @@ import org.opennms.alec.engine.api.Engine;
 import org.opennms.alec.engine.api.EngineFactory;
 import org.opennms.alec.engine.dbscan.DBScanEngineFactory;
 
+import com.codahale.metrics.MetricRegistry;
 import com.google.common.collect.Sets;
 
 /**
@@ -98,10 +99,11 @@ public class Level1EngineComplianceTest {
 
     @Test
     public void canCreateDistinctEngines() {
-        Engine engine1 = factory.createEngine();
+        MetricRegistry metrics = new MetricRegistry();
+        Engine engine1 = factory.createEngine(metrics);
         assertThat(engine1, notNullValue());
 
-        Engine engine2 = factory.createEngine();
+        Engine engine2 = factory.createEngine(metrics);
         assertThat(engine2, notNullValue());
         assertThat(engine1, not(sameInstance(engine2)));
     }

--- a/features/deeplearning/src/main/java/org/opennms/features/deeplearning/shell/Vectorize.java
+++ b/features/deeplearning/src/main/java/org/opennms/features/deeplearning/shell/Vectorize.java
@@ -65,6 +65,8 @@ import org.opennms.alec.engine.deeplearning.InputVector;
 import org.opennms.alec.engine.deeplearning.OutputVector;
 import org.opennms.alec.engine.deeplearning.Vectorizer;
 
+import com.codahale.metrics.MetricRegistry;
+
 import edu.uci.ics.jung.graph.Graph;
 
 @Command(scope = "opennms-alec", name = "tensorflow-vectorize", description = "Convert a fault data set to vectors for the purpose of training a TensorFlow model.")
@@ -119,6 +121,7 @@ public class Vectorize implements Action {
         private Vectorizer vectorizer;
 
         private MyEngine(Set<Situation> situations, Consumer<OutputVector> consumer) {
+            super(new MetricRegistry());
             this.situations = Objects.requireNonNull(situations);
             this.consumer = Objects.requireNonNull(consumer);
 
@@ -187,7 +190,7 @@ public class Vectorize implements Action {
         }
 
         @Override
-        public Engine createEngine() {
+        public Engine createEngine(MetricRegistry metrics) {
             return engine;
         }
     }

--- a/features/graph/rest/src/test/java/org/opennms/alec/feature/graph/rest/impl/MockGraphProvider.java
+++ b/features/graph/rest/src/test/java/org/opennms/alec/feature/graph/rest/impl/MockGraphProvider.java
@@ -43,11 +43,12 @@ import org.opennms.alec.engine.dbscan.DBScanEngine;
 import org.opennms.alec.features.graph.api.GraphProvider;
 import org.opennms.alec.features.graph.api.OceGraph;
 
+import com.codahale.metrics.MetricRegistry;
 import com.google.common.collect.Lists;
 
 public class MockGraphProvider implements GraphProvider {
 
-    final DBScanEngine dbScanEngine = new DBScanEngine();
+    final DBScanEngine dbScanEngine = new DBScanEngine(new MetricRegistry());
 
     public MockGraphProvider() {
         final InventoryObject io1 = ImmutableInventoryObject.newBuilder()

--- a/karaf-features/pom.xml
+++ b/karaf-features/pom.xml
@@ -130,6 +130,7 @@
                                 <feature>jackson-jaxrs</feature>
                                 <feature>tensorflow</feature>
                                 <feature>groovy</feature>
+                                <feature>dropwizard-metrics</feature>
                             </features>
                         </configuration>
                     </execution>

--- a/karaf-features/src/main/resources/features.xml
+++ b/karaf-features/src/main/resources/features.xml
@@ -69,6 +69,7 @@
 
     <feature name="alec-engine-api" description="ALEC :: Engine :: API" version="${project.version}">
         <feature version="${project.version}">alec-datasource-api</feature>
+        <feature dependency="true" version="${metrics.version}">dropwizard-metrics</feature>
         <bundle>mvn:org.opennms.alec.engine/org.opennms.alec.engine.api/${project.version}</bundle>
     </feature>
 
@@ -100,8 +101,6 @@
         <feature version="${opennms.api.version}" dependency="true">opennms-integration-api</feature>
         <feature version="${project.version}">alec-engine-api</feature>
         <feature version="${project.version}">alec-processor-api</feature>
-        <bundle dependency="true">mvn:io.dropwizard.metrics/metrics-core/${metrics.version}</bundle>
-        <bundle dependency="true">mvn:io.dropwizard.metrics/metrics-jmx/${metrics.version}</bundle>
         <bundle>mvn:org.opennms.alec.driver/org.opennms.alec.driver.main/${project.version}</bundle>
     </feature>
 
@@ -284,6 +283,11 @@
 
     <feature name="groovy" description="Groovy" version="${groovy.version}">
         <bundle>mvn:org.codehaus.groovy/groovy-all/${groovy.version}</bundle>
+    </feature>
+
+    <feature name="dropwizard-metrics" description="Dropwizard :: Metrics" version="${metrics.version}">
+        <bundle dependency="true">mvn:io.dropwizard.metrics/metrics-core/${metrics.version}</bundle>
+        <bundle dependency="true">mvn:io.dropwizard.metrics/metrics-jmx/${metrics.version}</bundle>
     </feature>
 
 </features>


### PR DESCRIPTION
Here we update the way metrics are managed and exposed, making it easier for engines to expose them.

We leverage this to expose graph statistics in the `cluster` engines:
 * Number of edges
 * Number of vertices
 * Number of situations
 * Number of alarms

In addition to the existing tick timings.