### PR TITLE
ALEC-77: Upgrade Alec Kafka Components to 2.3.0 on Scala 2.12

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,16 +59,16 @@
         <gson.version>2.8.2</gson.version>
         <hamcrest.version>1.3</hamcrest.version>
         <java.version>1.8</java.version>
-        <jackson.version>2.9.8</jackson.version>
+        <jackson.version>2.9.9</jackson.version>
         <jackson-annotations.version>2.9.0</jackson-annotations.version>
         <jung.version>2.1.1</jung.version>
         <junit.version>4.12</junit.version>
-        <kafka.bundle.version>2.2.0_1</kafka.bundle.version>
+        <kafka.bundle.version>2.3.0_1</kafka.bundle.version>
         <kafka.scala.version>2.12</kafka.scala.version>
-        <kafka.version>2.2.0</kafka.version>
+        <kafka.version>2.3.0</kafka.version>
         <karaf.version>4.2.3</karaf.version>
         <log4j.version>2.8.2</log4j.version>
-        <lz4.version>1.5.0</lz4.version>
+        <lz4.version>1.6.0</lz4.version>
         <metrics.version>4.1.0</metrics.version>
         <mockito.version>2.18.0</mockito.version>
         <moxy.version>2.7.3</moxy.version>
@@ -80,9 +80,9 @@
         <osgi.version>6.0.0</osgi.version>
         <osgi.compendium.version>5.0.0</osgi.compendium.version>
         <protobuf.version>3.5.1</protobuf.version>
-        <rocksdb.version>5.15.10</rocksdb.version>
-        <slf4j-api.version>1.7.25</slf4j-api.version>
-        <snappy-java.version>1.1.7.2</snappy-java.version>
+        <rocksdb.version>5.18.3</rocksdb.version>
+        <slf4j-api.version>1.7.26</slf4j-api.version>
+        <snappy-java.version>1.1.7.3</snappy-java.version>
         <snmp4j.bundle.version>2.6.3_1</snmp4j.bundle.version>
         <spring.kafka.version>2.2.7.RELEASE</spring.kafka.version>
         <string.similarity.version>1.1.0</string.similarity.version>


### PR DESCRIPTION
ALEC-77: Upgrade Alec Kafka Components to 2.3.0 on Scala 2.12

**External References**
* JIRA (Issue Tracker): https://issues.opennms.org/browse/ALEC-77