### PR TITLE
Bug ALEC-80 - The Kafka Topic edgesTopic from the configuration is ignored

### DIFF
--- a/datasource/opennms-kafka/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/datasource/opennms-kafka/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -49,6 +49,7 @@
         <property name="alarmTopic" value="${alarmTopic}"/>
         <property name="alarmFeedbackTopic" value="${alarmFeedbackTopic}"/>
         <property name="nodeTopic" value="${nodeTopic}"/>
+        <property name="edgesTopic" value="${edgesTopic}"/>
         <property name="eventSinkTopic" value="${eventSinkTopic}"/>
         <property name="inventoryTopic" value="${inventoryTopic}"/>
         <property name="inventoryTtlMs" value="${inventoryTtlMs}"/>


### PR DESCRIPTION
Inside the blueprint, an entry to configure the service based on the configuration file for the `edgesTopic` was missing, and it has been added similar to the other entries.

https://issues.opennms.org/browse/ALEC-80