### PR TITLE
ALEC-81: Use ISO-8601 date format

### DIFF
--- a/datasource/opennms-kafka/src/main/java/org/opennms/alec/datasource/opennms/OpennmsDatasource.java
+++ b/datasource/opennms-kafka/src/main/java/org/opennms/alec/datasource/opennms/OpennmsDatasource.java
@@ -156,6 +156,8 @@ public class OpennmsDatasource implements SituationDatasource, AlarmDatasource, 
     private final EdgeToInventory edgeToInventory;
 
     private final SinkWrapper sinkWrapper;
+    
+    private Event.TimeFormat eventTimeFormat = Event.TimeFormat.ISO;
 
     public OpennmsDatasource(ConfigurationAdmin configAdmin, NodeToInventory nodeToInventory, AlarmToInventory alarmToInventory,
             EdgeToInventory edgeToInventory, SinkWrapper sinkWrapper) {
@@ -557,7 +559,7 @@ public class OpennmsDatasource implements SituationDatasource, AlarmDatasource, 
             return;
         }
 
-        final Event e = SituationToEvent.toEvent(situation);
+        final Event e = SituationToEvent.toEvent(situation, eventTimeFormat);
         final String situationXml = JaxbUtils.toXml(new Log(e), Log.class);
         LOG.debug("Sending event to create situation with id '{}'. XML: {}", situation.getId(), situationXml);
 
@@ -650,6 +652,11 @@ public class OpennmsDatasource implements SituationDatasource, AlarmDatasource, 
 
     public void setWrapSinkMessagesInProto(boolean wrapSinkMessagesInProto) {
         this.wrapSinkMessagesInProto = wrapSinkMessagesInProto;
+    }
+
+    public void setEventTimeFormat(String eventTimeFormat) {
+        Objects.requireNonNull(eventTimeFormat);
+        this.eventTimeFormat = Event.TimeFormat.valueOf(eventTimeFormat.toUpperCase());
     }
 
     @Override

--- a/datasource/opennms-kafka/src/main/java/org/opennms/alec/datasource/opennms/SituationToEvent.java
+++ b/datasource/opennms-kafka/src/main/java/org/opennms/alec/datasource/opennms/SituationToEvent.java
@@ -45,8 +45,8 @@ public class SituationToEvent {
     public static final String SITUATION_UEI = "uei.opennms.org/alarms/situation";
     public static final String SITUATION_ID_PARM_NAME = "situationId";
 
-    public static Event toEvent(Situation situation) {
-        final Event e = new Event();
+    public static Event toEvent(Situation situation, Event.TimeFormat timeFormat) {
+        final Event e = Event.withDateFormat(timeFormat);
         e.setUei(SITUATION_UEI);
 
         // Use the max severity as the situation severity

--- a/datasource/opennms-kafka/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/datasource/opennms-kafka/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -15,6 +15,7 @@
             <cm:property name="scriptFile" value="" /> <!--  use empty string to use default script included in bundle" -->
             <cm:property name="scriptCacheMillis" value="30000"/>  <!-- 30 seconds -->
             <cm:property name="wrapSinkMessagesInProto" value="true"/>
+            <cm:property name="eventTimeFormat" value="iso"/> <!-- one of "iso" or "simple" -->
         </cm:default-properties>
     </cm:property-placeholder>
 
@@ -54,6 +55,7 @@
         <property name="inventoryTtlMs" value="${inventoryTtlMs}"/>
         <property name="inventoryGcIntervalMs" value="${inventoryGcIntervalMs}"/>
         <property name="wrapSinkMessagesInProto" value="${wrapSinkMessagesInProto}"/>
+        <property name="eventTimeFormat" value="${eventTimeFormat}"/>
     </bean>
     <service ref="opennmsDatasource" interface="org.opennms.alec.datasource.api.AlarmDatasource"/>
     <service ref="opennmsDatasource" interface="org.opennms.alec.datasource.api.AlarmFeedbackDatasource"/>

--- a/datasource/opennms-kafka/src/test/java/org/opennms/alec/datasource/opennms/events/EventMarshalTest.java
+++ b/datasource/opennms-kafka/src/test/java/org/opennms/alec/datasource/opennms/events/EventMarshalTest.java
@@ -35,6 +35,7 @@ import static org.hamcrest.Matchers.hasSize;
 import static org.xmlunit.matchers.CompareMatcher.isSimilarTo;
 
 import java.text.ParseException;
+import java.time.ZonedDateTime;
 import java.util.Date;
 
 import org.junit.Test;
@@ -44,7 +45,7 @@ public class EventMarshalTest {
     @Test
     public void canMarshalAndUnmarshal() {
         Event e = new Event();
-        e.setTime("Tuesday, 9 April 2019 14:07:27 o'clock EDT");
+        e.setTime("2019-10-21T22:30:43.103-04:00");
         e.setUei("someuei");
         e.setNodeId(99L);
         e.addParam("k1", "v1");
@@ -64,7 +65,7 @@ public class EventMarshalTest {
                 "        </parm>\n" +
                 "    </parms>\n" +
                 "    <severity>Critical</severity>\n" +
-                "    <time>Tuesday, 9 April 2019 14:07:27 o'clock EDT</time>\n" +
+                "    <time>2019-10-21T22:30:43.103-04:00</time>\n" +
                 "    <nodeid>99</nodeid>\n" +
                 "</event>"));
         assertThat(JaxbUtils.fromXml(JaxbUtils.toXml(e, Event.class), Event.class), equalTo(e));
@@ -87,7 +88,7 @@ public class EventMarshalTest {
                 "                </parm>\n" +
                 "            </parms>\n" +
                 "            <severity>Critical</severity>\n" +
-                "            <time>Tuesday, 9 April 2019 14:07:27 o'clock EDT</time>\n" +
+                "            <time>2019-10-21T22:30:43.103-04:00</time>\n" +
                 "            <nodeid>99</nodeid>\n" +
                 "        </event>\n" +
                 "    </events>\n" +
@@ -96,12 +97,12 @@ public class EventMarshalTest {
     }
 
     @Test
-    public void canParseDate() throws ParseException {
+    public void canParseDate() {
         Date start = new Date();
 
         // Create a new event and parse the date from the default string that was generated
         Event e = new Event();
-        Date dateFromEvent = Event.getDateFormat().parse(e.getTime());
+        Date dateFromEvent = Date.from(ZonedDateTime.parse(e.getTime()).toInstant());
 
         // The parsed date should be >= the date from the start of the test - add 1 second to adjust for miissing millis
         assertThat(dateFromEvent.getTime() + 1000, greaterThanOrEqualTo(start.getTime()));

--- a/docs/modules/datasources/pages/kafka.adoc
+++ b/docs/modules/datasources/pages/kafka.adoc
@@ -29,6 +29,20 @@ These topics are expected to exist in the Kafka broker for the datasource to ope
 |inventoryTopic      | `alec-inventory`      | Used to maintain inventory state
 |=======
 
+== Event Compatibility
+
+The following property is used to determine how event creation times are encoded when ALEC sends events via Kafka to
+OpenNMS. The value should be set depending on the version of OpenNMS being used.
+
+[options="header"]
+|=======
+|Property            | Default Value         | Description
+|eventTimeFormat     | `iso`                 | The time format used to encode event creation times
+|=======
+
+For any OpenNMS version < Horizon 25.1.0 or < Meridian 2019.1.0 the value should be set to "simple". Otherwise the
+default value of "iso" should be used.
+
 == Scripted extensions
 
 === Config

--- a/smoke-test/src/main/resources/overlays/sentinel-overlay/etc/org.opennms.alec.datasource.opennms.kafka.cfg
+++ b/smoke-test/src/main/resources/overlays/sentinel-overlay/etc/org.opennms.alec.datasource.opennms.kafka.cfg
@@ -1,0 +1,1 @@
+eventTimeFormat = simple


### PR DESCRIPTION
This PR updates how event times are formatted on ALEC. The new behaviour is configurable and defaults to using the ISO format. The old format can also be used by changing a configuration property. For the existing smoke tests, the old format is used since the OpenNMS version that is tested against expects that format.

I tested this using the existing smoke test. With the new changes and without setting the property to use the old format, the tests fail. When setting the property to use the old format, the tests pass as expected.

Jira: https://issues.opennms.org/browse/ALEC-81