### PR TITLE
ALEC-82: OpenNMS Direct Inventory Datasource Peformance Issues

### DIFF
--- a/datasource/opennms-direct/src/test/java/org/opennms/alec/datasource/opennms/jvm/DirectInventoryDatasourceTest.java
+++ b/datasource/opennms-direct/src/test/java/org/opennms/alec/datasource/opennms/jvm/DirectInventoryDatasourceTest.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2018 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2018 The OpenNMS Group, Inc.
+ * Copyright (C) 2019 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2019 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -77,7 +77,7 @@ public class DirectInventoryDatasourceTest {
 
     @Before
     public void setUp() {
-        dic.init();
+        dic.doInit();
     }
 
     /**


### PR DESCRIPTION
JIRA: https://issues.opennms.org/browse/ALEC-82

-On startup, inventory is now loaded in dedicated thread. Given this is a
  long running operation, the Blueprint thread can proceed to initializing other
  bundles.
-The detection mechanism for new inventory has been updated for performance.