### PR TITLE
ALEC-82: Review thread synchronization and locking to avoid deadlocks.

### DIFF
--- a/datasource/opennms-direct/src/main/java/org/opennms/alec/datasource/opennms/jvm/DirectInventoryDatasource.java
+++ b/datasource/opennms-direct/src/main/java/org/opennms/alec/datasource/opennms/jvm/DirectInventoryDatasource.java
@@ -608,9 +608,8 @@ public class DirectInventoryDatasource implements InventoryDatasource, AlarmLife
 
     @Override
     public void handleAlarmSnapshot(List<Alarm> alarms) {
-        if (LOG.isTraceEnabled()) {
-            LOG.trace("Received alarm snapshot {}", alarms);
-        }
+        LOG.trace("Received alarm snapshot {}", alarms);
+        waitForInit(); // Wait for initialization before acquiring the write lock to avoid deadlocks
         inventoryLock.writeLock().lock();
         try {
             // Derive new inventory from the snapshot
@@ -636,6 +635,7 @@ public class DirectInventoryDatasource implements InventoryDatasource, AlarmLife
     @Override
     public void handleDeletedAlarm(int alarmId, String reductionKey) {
         LOG.trace("Received delete for alarm Id {}", alarmId);
+        waitForInit(); // Wait for initialization before acquiring the write lock to avoid deadlocks
         inventoryLock.writeLock().lock();
         try {
             // Check if this alarm had any inventory associated


### PR DESCRIPTION
JIRA: https://issues.opennms.org/browse/ALEC-82

With the original patch for ALEC-82 we moved the initialization code to a separate thread which turned out to cause deadlocks.

Here we review the concurrency in the direct data-source and move to use read-write locks instead of the synchronized keyword. Locking is done after call to `#waitForInit` to avoid blocking other threads (and potentially deadlocking) while we wait.
