### PR TITLE
ALEC-85: ALEC smoke tests currently failing loading in Sentinel

### DIFF
--- a/datasource/opennms-kafka/src/main/java/org/opennms/alec/datasource/opennms/KafkaStreamMonitor.java
+++ b/datasource/opennms-kafka/src/main/java/org/opennms/alec/datasource/opennms/KafkaStreamMonitor.java
@@ -87,7 +87,7 @@ public class KafkaStreamMonitor implements KafkaStreams.StateListener {
     private synchronized KafkaStreams.State restartKafka() {
         // double check that the restart is still needed (maybe the state has changed back to RUNNING already)
         if(KafkaStreams.State.ERROR != this.currentState) {
-            LOG.info("State is {}, not {}, restart sees to have been sucessful. Will abort.", this.currentState, KafkaStreams.State.ERROR);
+            LOG.info("State is {}, not {}, restart seems to have been successful. Will abort.", this.currentState, KafkaStreams.State.ERROR);
             return this.currentState; // nothing to do
         }
         try {

--- a/datasource/opennms-kafka/src/main/java/org/opennms/alec/datasource/opennms/OpennmsDatasource.java
+++ b/datasource/opennms-kafka/src/main/java/org/opennms/alec/datasource/opennms/OpennmsDatasource.java
@@ -179,9 +179,12 @@ public class OpennmsDatasource implements SituationDatasource, AlarmDatasource, 
         // Use the class-loader for the KStream class, since the kafka-client bundle
         // does not import the required classes from the kafka-streams bundle
         streams = KafkaUtils.runWithGivenClassLoader(() -> new KafkaStreams(getKTopology(), streamProperties), KStream.class.getClassLoader());
-        if(this.streamStateListener != null) {
-            streams.setStateListener(streamStateListener);
+        
+        if(this.streamStateListener == null) {
+            LOG.debug("Creating a new Kafka Stream Monitor");
+            this.streamStateListener = new KafkaStreamMonitor(this);
         }
+        streams.setStateListener(streamStateListener);
 
         streams.setUncaughtExceptionHandler((t, e) ->
                 LOG.error(String.format("Stream error on thread: %s", t.getName()), e));
@@ -676,9 +679,5 @@ public class OpennmsDatasource implements SituationDatasource, AlarmDatasource, 
         LOG.debug("Waiting for alarm feedback store...");
         waitUntilAlarmFeedbackStoreIsQueryable();
         LOG.debug("All stores are available");
-    }
-
-    public void setStreamStateListener(final KafkaStreams.StateListener streamStateListener) {
-        this.streamStateListener = streamStateListener;
     }
 }

--- a/datasource/opennms-kafka/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/datasource/opennms-kafka/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -41,10 +41,6 @@
     <reference id="configAdmin" interface="org.osgi.service.cm.ConfigurationAdmin" />
     <reference id="sinkWrapper" interface="org.opennms.alec.integrations.opennms.sink.api.SinkWrapper" />
 
-    <bean id="streamMonitor" class="org.opennms.alec.datasource.opennms.KafkaStreamMonitor" destroy-method="destroy"/>
-
-    <service ref="streamStateListener" interface="org.apache.kafka.streams.KafkaStreams.StateListener"/>
-
     <bean id="opennmsDatasource" class="org.opennms.alec.datasource.opennms.OpennmsDatasource" init-method="init" destroy-method="destroy">
         <argument ref="configAdmin"/>
         <argument ref="nodeToInventory"/>
@@ -59,7 +55,6 @@
         <property name="inventoryTopic" value="${inventoryTopic}"/>
         <property name="inventoryTtlMs" value="${inventoryTtlMs}"/>
         <property name="inventoryGcIntervalMs" value="${inventoryGcIntervalMs}"/>
-        <property name="streamStateListener" value="streamStateListener"/>
         <property name="wrapSinkMessagesInProto" value="${wrapSinkMessagesInProto}"/>
         <property name="eventTimeFormat" value="${eventTimeFormat}"/>
     </bean>

--- a/datasource/opennms-kafka/src/test/java/org/opennms/alec/datasource/opennms/OpennmsDatasourceIT.java
+++ b/datasource/opennms-kafka/src/test/java/org/opennms/alec/datasource/opennms/OpennmsDatasourceIT.java
@@ -85,8 +85,6 @@ public abstract class OpennmsDatasourceIT {
         SinkWrapper sinkWrapper = mock(SinkWrapper.class);
         datasource = new OpennmsDatasource(getDatasourceConfig(), nodeToInventory, alarmToInventory, edgeToInventory, sinkWrapper);
         MockitoAnnotations.initMocks(this); // make the @Spy work
-        KafkaStreamMonitor streamMonitor = new KafkaStreamMonitor(datasource);
-        datasource.setStreamStateListener(streamMonitor);
     }
 
     public ConfigurationAdmin getDatasourceConfig() throws IOException {

--- a/smoke-test/src/main/resources/docker_fixed_images
+++ b/smoke-test/src/main/resources/docker_fixed_images
@@ -7,5 +7,5 @@ kafka=confluentinc/cp-kafka:4.0.0
 postgres=postgres:10.7-alpine
 # Note this tag version should match the selenium version in the POM
 selenium=selenium/standalone-chrome-debug:3.4.0
-sentinel=opennms/sentinel:25.1.1
-opennms=opennms/horizon:25.1.1
+sentinel=opennms/sentinel:26.1.1
+opennms=opennms/horizon:26.1.1


### PR DESCRIPTION
Smoke tests are failing for ALEC due to a few issues introduced recently. This PR fixes those issues to get them running again.

- Bumped OpenNMS and sentinel versions for smoke test due to new dependencies
- Fixed circular reference in OSGi service KafkaStreamMonitor

Jira: https://issues.opennms.org/browse/ALEC-85