### PR TITLE
ALEC-92: Add Antora Xref validation in ALEC CI/CD

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,7 @@ executors:
 
   docs-executor:
     docker:
-      - image: antora/antora:2.3.4
+      - image: opennms/antora:2.3.4-b6293
 
   netlify-cli-executor:
     docker:
@@ -382,11 +382,6 @@ jobs:
     steps:
       - attach_workspace:
           at: ~/
-      - run:
-          name: Install dependencies
-          command: |
-            apk --no-cache add git openssh-client
-            npm i -g gitlab:antora/xref-validator
       - run:
           name: Validate Xrefs in docs
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,7 @@ executors:
 
   docs-executor:
     docker:
-      - image: antora/antora:2.0.0
+      - image: antora/antora:2.3.4
 
   netlify-cli-executor:
     docker:
@@ -383,9 +383,18 @@ jobs:
       - attach_workspace:
           at: ~/
       - run:
-          name: Generate HTML output for documentation
+          name: Install dependencies
           command: |
-            antora generate site.yml
+            apk --no-cache add git openssh-client
+            npm i -g gitlab:antora/xref-validator
+      - run:
+          name: Validate Xrefs in docs
+          command: |
+            NODE_PATH="$(npm -g root)" antora --generator @antora/xref-validator site.yml
+      - run:
+          name: Build docs with Antora
+          command: |
+             NODE_PATH="$(npm -g root)" antora --stacktrace generate site.yml
 
       - store_artifacts:
           path: build/site.zip

--- a/site.yml
+++ b/site.yml
@@ -10,7 +10,7 @@ content:
     start_path: docs
 ui:
   bundle:
-    url: https://github.com/opennms-forge/antora-ui-opennms/releases/download/v1.0.1/ui-bundle.zip
+    url: https://github.com/opennms-forge/antora-ui-opennms/releases/download/v1.3.1/ui-bundle.zip
 asciidoc:
   attributes:
     stem: latexmath


### PR DESCRIPTION
I have added a local Antora build run that produces a static HTML site.zip as an artifact just with the content from the specific branch. It should give a developer and reviewer quicker feedback for validation. Added also an Xref validation step which blames when cross-references can't be resolved correctly.

- JIRA (Issue Tracker): http://issues.opennms.org/browse/ALEC-92