### PR TITLE
Feature/fix health check

### DIFF
--- a/driver/main/src/main/java/org/opennms/alec/driver/main/DriverHealthCheck.java
+++ b/driver/main/src/main/java/org/opennms/alec/driver/main/DriverHealthCheck.java
@@ -70,6 +70,6 @@ public class DriverHealthCheck implements HealthCheck {
         }
 
         // All checks passed
-        return ImmutableResponse.newInstance(Status.Success, String.format("Engine: %s - Tick duration (99 percentile): %d ms", driver.getEngineFactory().getNameConf(), tickDuration99Ms));
+        return ImmutableResponse.newInstance(Status.Success, String.format("%s - Tick duration (99 percentile): %d ms", driver.getEngineFactory().getName(), tickDuration99Ms));
     }
 }

--- a/engine/dbscan/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/engine/dbscan/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -15,7 +15,7 @@
     <bean id="alarmInSpaceAndTimeDistanceMeasureFactory" class="org.opennms.alec.engine.dbscan.AlarmInSpaceAndTimeDistanceMeasureFactory"/>
 
     <!-- Create and expose the engine factory -->
-    <service interface="org.opennms.alec.engine.api.EngineFactory" ranking="10">
+    <service interface="org.opennms.alec.engine.api.EngineFactory" ranking="20">
         <bean class="org.opennms.alec.engine.dbscan.DBScanEngineFactory">
             <argument value="${alpha}"/>
             <argument value="${beta}"/>

--- a/engine/deeplearning/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/engine/deeplearning/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -20,7 +20,7 @@
     </bean>
 
     <!-- Create and expose the engine factory -->
-    <service interface="org.opennms.alec.engine.api.EngineFactory" ranking="20">
+    <service interface="org.opennms.alec.engine.api.EngineFactory" ranking="10">
         <bean class="org.opennms.alec.engine.deeplearning.DeepLearningEngineFactory">
             <argument index="0" ref="blueprintBundleContext"/>
             <argument index="1" ref="deepLearningEngineConf"/>


### PR DESCRIPTION
Fix healthCheck (name of engine + parameters was too long) only show engine

prefer dbscan for default engine because of tensorflow (needed with deeplearning local) library not available on macos