### PR TITLE
fix ref to install alec

### DIFF
--- a/docs/modules/quick-start/pages/introduction.adoc
+++ b/docs/modules/quick-start/pages/introduction.adoc
@@ -1,6 +1,6 @@
 
 = Quick Start
 
-This Quick Start guide assumes that you have already https://docs.opennms.com/horizon/31/operation/quick-start/inventory.html[deployed an OpenNMS instance], followed the https://docs.opennms.com/horizon/31/operation/quick-start/introduction.html[core Quick Start guide], and xref:install:common_install.adoc[installed ALEC].
+This Quick Start guide assumes that you have already https://docs.opennms.com/horizon/31/operation/quick-start/inventory.html[deployed an OpenNMS instance], followed the https://docs.opennms.com/horizon/31/operation/quick-start/introduction.html[core Quick Start guide], and xref:install:basic_install.adoc[installed ALEC].
 
 This guide includes steps to set up the ALEC plugin, and involves minimal configuration.


### PR DESCRIPTION
Build failed with: 
https://app.circleci.com/pipelines/github/OpenNMS/alec/1316/workflows/6c72b816-5260-4692-a879-5983ef6e443d/jobs/7359

> Unresolved xrefs (grouped by origin):
> repo: https://github.com/OpenNMS/alec.git | branch: develop | component: alec | version: 3.0.0-SNAPSHOT
>  path: docs/modules/quick-start/pages/introduction.adoc | xref: install:common_install.adoc
> antora: xref validation failed! Found 1 unresolved xref. See previous report for details.
> Exited with code exit status 1
