### PR TITLE
Update the labeler to use the latest ubuntu image

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -5,7 +5,7 @@ name: PR-Labeler
 on: [pull_request]
 jobs:
   label:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       # We need to checkout the repository to access the configured file (.github/label-pr.yml)
       - uses: actions/checkout@v2


### PR DESCRIPTION
The Ubuntu-18.04 environment we are using for PR Labeler is deprecated.