### PR TITLE
ALEC-268:remove reference to layout in docs index file

### DIFF
--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -1,5 +1,4 @@
 = User's Guide to ALEC
-:page-layout: home
 :!sectids:
 
 Welcome to the Architecture for Learning Enabled Correlation (ALEC).


### PR DESCRIPTION
Removed reference to layout:home that was causing issues for the docs build.