### PR TITLE
DP-84: Add meta descriptions to each page in the Alec & Helm docs

### DIFF
--- a/docs/antora.yml
+++ b/docs/antora.yml
@@ -1,5 +1,8 @@
 name: alec
 version: '3.0.2-SNAPSHOT'
 title: ALEC
+asciidoc:
+  attributes:
+    full-display-version: '3.0.2-SNAPSHOT'
 nav:
   - modules/ROOT/nav.adoc

--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -1,5 +1,6 @@
 = User's Guide to ALEC
 :!sectids:
+:description: Get an overview of OpenNMS's Architecture for Learning Enabled Correlation (ALEC) that uses machine learning to logically group related alarms.
 
 Welcome to the Architecture for Learning Enabled Correlation (ALEC).
 This guide provides information and procedures to help you understand and deploy the advanced software concepts and components that make up ALEC.

--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -2,6 +2,12 @@
 :!sectids:
 :description: Get an overview of OpenNMS's Architecture for Learning Enabled Correlation (ALEC) that uses machine learning to logically group related alarms.
 
+[options="autowidth"]
+|===
+|Version:     |{full-display-version}
+|Last update: |{docdatetime}
+|===
+
 Welcome to the Architecture for Learning Enabled Correlation (ALEC).
 This guide provides information and procedures to help you understand and deploy the advanced software concepts and components that make up ALEC.
 

--- a/docs/modules/about/pages/welcome.adoc
+++ b/docs/modules/about/pages/welcome.adoc
@@ -1,6 +1,7 @@
 
 :imagesdir: ../assets/images
 = About ALEC
+:description: Learn how OpenNMS's Architecture for Learning Enabled Correlation (ALEC) uses machine learning to logically group related alarms into higher-level situations.
 
 The Architecture for Learning Enabled Correlation (ALEC) provides a machine learning-powered framework for logically grouping related alarms into higher-level situations.
 

--- a/docs/modules/install/pages/basic_install.adoc
+++ b/docs/modules/install/pages/basic_install.adoc
@@ -1,6 +1,7 @@
 
 :imagesdir: ../assets/images
 = Basic Installation
+:description: Learn how to install OpenNMS's Architecture for Learning Enabled Correlation (ALEC) to enable machine-learning alarm grouping.
 
 This section describes a basic installation, where ALEC runs as another service within your OpenNMS Horizon or Meridian instance:
 

--- a/docs/modules/install/pages/introduction.adoc
+++ b/docs/modules/install/pages/introduction.adoc
@@ -1,5 +1,6 @@
 
 = Installation Overview
+:description: View the prerequisites to install OpenNMS's Architecture for Learning Enabled Correlation (ALEC) and the benefits of basic vs. distributed deployment.
 
 There are two options available for ALEC deployment: basic and distributed installations.
 

--- a/docs/modules/install/pages/pre_install.adoc
+++ b/docs/modules/install/pages/pre_install.adoc
@@ -1,6 +1,7 @@
 
 :imagesdir: ../assets/images
 = Pre-Installation Tasks
+:description: View pre-installation tasks for OpenNMS's Architecture for Learning Enabled Correlation (ALEC): configuration, enable alarm history storage and syslogd, etc.
 
 This section describes the configuration tasks that you must complete before installing ALEC.
 

--- a/docs/modules/quick-start/pages/engine-config.adoc
+++ b/docs/modules/quick-start/pages/engine-config.adoc
@@ -1,6 +1,7 @@
 
 :imagesdir: ../assets/images
 = Step 1: First-Time Login and Engine Configuration
+:description: View first-time login tasks and how to configure a correlation engine in OpenNMS's Architecture for Learning Enabled Correlation (ALEC).
 
 This section explains first-time login tasks and how to configure a correlation engine.
 ALEC includes two correlation engines: clustering and deep learning.

--- a/docs/modules/quick-start/pages/introduction.adoc
+++ b/docs/modules/quick-start/pages/introduction.adoc
@@ -1,5 +1,6 @@
 
 = Quick Start
+:description: Read the quick start guide overview for OpenNMS's Architecture for Learning Enabled Correlation (ALEC).
 
 This Quick Start guide assumes that you have already https://docs.opennms.com/horizon/31/operation/quick-start/inventory.html[deployed an OpenNMS instance], followed the https://docs.opennms.com/horizon/31/operation/quick-start/introduction.html[core Quick Start guide], and xref:install:basic_install.adoc[installed ALEC].
 

--- a/docs/modules/quick-start/pages/situations.adoc
+++ b/docs/modules/quick-start/pages/situations.adoc
@@ -1,6 +1,7 @@
 
 :imagesdir: ../assets/images
 = Step 2: View and Create Situations
+:description: Learn how to view and create situations in OpenNMS's Architecture for Learning Enabled Correlation (ALEC) to enable machine-learning alarm grouping.
 
 Now that you have xref:engine-config.adoc[selected the clustering engine], ALEC automatically begins to identify situations.
 This requires new alarms to be triggered within your OpenNMS environment, so--depending on your network's usual activity--this may take some time.

--- a/docs/modules/reference/pages/architecture/opennms_integration.adoc
+++ b/docs/modules/reference/pages/architecture/opennms_integration.adoc
@@ -1,6 +1,7 @@
 
 :imagesdir: ../assets/images
 = OpenNMS Integration
+:description: Understand the alarm lifecycle and correlation process between OpenNMS Horizon/Meridian and its Architecture for Learning Enabled Correlation (ALEC).
 
 The lifecycle of an alarm and the correlation process between OpenNMS and ALEC involves various components:
 

--- a/docs/modules/reference/pages/architecture/overview.adoc
+++ b/docs/modules/reference/pages/architecture/overview.adoc
@@ -1,6 +1,7 @@
 
 :imagesdir: ../assets/images
 = ALEC Architecture
+:description: Get an overview of OpenNMS's Architecture for Learning Enabled Correlation (ALEC) which enables machine-learning alarm grouping.
 
 ALEC provides a framework for developing correlation systems.
 

--- a/docs/modules/reference/pages/datasources/direct.adoc
+++ b/docs/modules/reference/pages/datasources/direct.adoc
@@ -1,5 +1,6 @@
 
 = Direct Datasource
+:description: Learn how OpenNMS's Architecture for Learning Enabled Correlation (ALEC) uses event hooks to collect alarm and network inventory data.
 
 The direct datasource is used with a xref:install:basic_install.adoc[basic installation of ALEC].
 It runs on the same JVM as OpenNMS, and acts on new alarms and inventory objects using the APIs provisioned by the https://docs.opennms.com/horizon/latest/development/oia/introduction.html[OpenNMS Plugin API].

--- a/docs/modules/reference/pages/datasources/kafka.adoc
+++ b/docs/modules/reference/pages/datasources/kafka.adoc
@@ -1,5 +1,6 @@
 
 = Kafka Datasource
+:description: Learn how the Kafka datasource works with a distributed installation of OpenNMS's Architecture for Learning Enabled Correlation (ALEC).
 
 The Kafka datasource is used with a xref:admin:distributed_install.adoc[distributed installation of ALEC].
 It interfaces with OpenNMS by leveraging the event consumer and Kafka Producer features.

--- a/docs/modules/reference/pages/datasources/overview.adoc
+++ b/docs/modules/reference/pages/datasources/overview.adoc
@@ -1,5 +1,6 @@
 
 = ALEC Datasources
+:description: Get an overview of the different datasources in OpenNMS's Architecture for Learning Enabled Correlation (ALEC): direct and Kafka.
 
 Datasources serve as the bridge between ALEC and OpenNMS.
 They provide and maintain a feed of alarms, inventory objects, and situations.

--- a/docs/modules/reference/pages/engines/clustering.adoc
+++ b/docs/modules/reference/pages/engines/clustering.adoc
@@ -1,5 +1,6 @@
 
 = Clustering Engine
+:description: Learn how to train the clustering engine in OpenNMS's Architecture for Learning Enabled Correlation (ALEC).
 
 The clustering engine is a xref:engines/introduction.adoc[correlation engine] that uses the https://en.wikipedia.org/wiki/DBSCAN[DBSCAN algorithm] to build alarm clusters.
 It draws information from the locally persisted network inventory graph.

--- a/docs/modules/reference/pages/engines/deeplearning.adoc
+++ b/docs/modules/reference/pages/engines/deeplearning.adoc
@@ -1,6 +1,7 @@
 
 :imagesdir: ../assets/images
 = Deep Learning Engine
+:description: Learn how to train the deep leaning engine in OpenNMS's Architecture for Learning Enabled Correlation (ALEC).
 
 The deep learning engine is a xref:engines/introduction.adoc[correlation engine] that uses a https://www.tensorflow.org/[TensorFlow] model to build alarm clusters.
 It draws information from the locally persisted network inventory graph.

--- a/docs/modules/reference/pages/engines/introduction.adoc
+++ b/docs/modules/reference/pages/engines/introduction.adoc
@@ -1,5 +1,6 @@
 
 = Correlation Engines
+:description: Learn how the correlation engines (clustering and deep learning) in OpenNMS's Architecture for Learning Enabled Correlation (ALEC) work.
 
 Correlation engines are the underlying processes that drive ALEC.
 Two engines are implemented by default: xref:engines/clustering.adoc[clustering] and xref:engines/deeplearning.adoc[deep learning].

--- a/docs/modules/reference/pages/glossary.adoc
+++ b/docs/modules/reference/pages/glossary.adoc
@@ -1,5 +1,6 @@
 
 = Glossary
+:description: Read the glossary for terms and concepts related to OpenNMS's Architecture for Learning Enabled Correlation (ALEC).
 
 This glossary defines terms that are specific to the OpenNMS ALEC plugin.
 For more general terminology related to the OpenNMS project, see the https://docs.opennms.com/horizon/latest/reference/glossary.html[core documentation].

--- a/docs/modules/reference/pages/model.adoc
+++ b/docs/modules/reference/pages/model.adoc
@@ -1,9 +1,10 @@
 
 = Model
+:description: View the list of object types supported in OpenNMS's Architecture for Learning Enabled Correlation (ALEC), that uses machine learning to group related alarms.
 
-== Types
+== Object types
 
-The following types are supported using built-in inventory scripts:
+The following object types are supported using built-in inventory scripts:
 
 [cols="1,3"]
 |===


### PR DESCRIPTION
DP-84: Add meta descriptions to each page in the Alec & Helm docs - added meta descriptions to Alec documentation for better SEO.

DP-83: Add doc information to each landing page - added doc info to the Alec docs.