### PR TITLE
ALEC-303: Bump vulnerable Maven dependencies (16 Dependabot alerts)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,29 +50,29 @@
         <asciitable.version>0.3.2</asciitable.version>
         <awaitility.version>3.1.1</awaitility.version>
         <commons.csv.version>1.5</commons.csv.version>
-        <commons.io.version>2.6</commons.io.version>
+        <commons.io.version>2.16.1</commons.io.version>
         <commons.lang3.version>3.7</commons.lang3.version>
         <commons.math.version>3.6.1</commons.math.version>
         <commons.text.version>1.3</commons.text.version>
         <cxf.version>3.2.6</cxf.version>
         <drools.version>7.7.0.Final</drools.version>
-        <guava.major.version>30</guava.major.version>
-        <guava.version>30.1.1-jre</guava.version>
-        <failureaccess.version>1.0.1</failureaccess.version>
+        <guava.major.version>33</guava.major.version>
+        <guava.version>33.4.8-jre</guava.version>
+        <failureaccess.version>1.0.3</failureaccess.version>
         <groovy.version>2.4.16</groovy.version>
-        <gson.version>2.8.2</gson.version>
+        <gson.version>2.10.1</gson.version>
         <hamcrest.version>1.3</hamcrest.version>
         <jakarta.version>2.3.3</jakarta.version>
         <java.version>17</java.version>
         <jackson.version>2.12.3</jackson.version>
         <jaxrs.version>2.1.1</jaxrs.version>
         <jung.version>2.1.1</jung.version>
-        <junit.version>4.12</junit.version>
+        <junit.version>4.13.2</junit.version>
         <kafka.bundle.version>3.1.0_1</kafka.bundle.version>
         <kafka.scala.version>2.13</kafka.scala.version>
         <kafka.version>3.1.0</kafka.version>
         <karaf.version>4.3.10</karaf.version>
-        <log4j.version>2.17.0</log4j.version>
+        <log4j.version>2.25.4</log4j.version>
         <lz4.version>1.6.0</lz4.version>
         <metrics.version>4.1.0</metrics.version>
         <mockito.version>2.18.0</mockito.version>

--- a/smoke-test/pom.xml
+++ b/smoke-test/pom.xml
@@ -13,8 +13,6 @@
         <jersey.version>2.28</jersey.version>
         <jsch.version>0.2.1</jsch.version>
         <selenium.version>3.6.0</selenium.version>
-        <!--This module needs a newer version of guava than the root pom version -->
-        <guava.version>28.0-jre</guava.version>
         <testcontainers.version>1.17.2</testcontainers.version>
     </properties>
     <build>
@@ -169,7 +167,7 @@
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
-            <version>2.5</version>
+            <version>${commons.io.version}</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>


### PR DESCRIPTION
Tracked by [ALEC-303](https://opennms.atlassian.net/browse/ALEC-303) — phase 1 of clearing the repo's 109 open Dependabot alerts. This PR addresses all 16 **Maven** alerts via root-pom property bumps; the 93 npm alerts (`ui/`) will follow in separate PRs to avoid conflicting with #156/#157.

## Changes

| Dependency | From | To | CVEs cleared |
|---|---|---|---|
| guava | 30.1.1-jre | 33.4.8-jre | CVE-2020-8908, CVE-2023-2976 |
| log4j | 2.17.0 | 2.25.4 | CVE-2021-44832, CVE-2025-68161, CVE-2026-34477, CVE-2026-34480 |
| commons-io | 2.6 / 2.5 | 2.16.1 | CVE-2021-29425, CVE-2024-47554 |
| gson | 2.8.2 | 2.10.1 | CVE-2022-25647 |
| junit | 4.12 | 4.13.2 | CVE-2020-15250 |

Supporting changes:
- `guava.major.version` 30 → 33 so the OSGi `Import-Package` ranges in the 10 module poms match the new guava.
- `failureaccess` 1.0.1 → 1.0.3 (guava 33.4.x companion; referenced by the Karaf `features.xml` bundles).
- smoke-test: removed the stale `guava.version=28.0-jre` override (it was *older* than the new root version despite its comment) and replaced the hardcoded commons-io 2.5 with the shared `${commons.io.version}` property.

All bundle references in `karaf-features/features.xml` flow through these same properties, so the KAR runtime picks up the fixed versions too.

## Verification
- All target versions confirmed present on Maven Central.
- Local `mvn clean install -DskipTests`: **BUILD SUCCESS** (compile, OSGi bundling, KAR assembly).
- Full test + smoke-test validation delegated to CircleCI (local run blocked by macOS-only RocksDB JNI / embedded-Kafka issues unrelated to this change).

Supersedes stale Dependabot PRs #135, #136, #139 (guava) — they can be closed once this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UB6PGc2rpPbojnqbTHU5ND