### PR TITLE
ALEC-306: Fix LLM clustering engine correctness (post-#157 review)

### DIFF
--- a/datasource/opennms-direct/src/main/java/org/opennms/alec/datasource/opennms/jvm/DirectInventoryDatasource.java
+++ b/datasource/opennms-direct/src/main/java/org/opennms/alec/datasource/opennms/jvm/DirectInventoryDatasource.java
@@ -282,10 +282,33 @@ public class DirectInventoryDatasource implements InventoryDatasource, AlarmLife
         }
     }
 
-    private void refreshEdgeTopology() {
+    void refreshEdgeTopology() {
         LOG.debug("Performing scheduled edge topology refresh from EdgeDao");
         try {
-            edgeDao.getEdges().forEach(this::processEdge);
+            Set<String> liveEdgeIds = new HashSet<>();
+            edgeDao.getEdges().forEach(e -> {
+                liveEdgeIds.add(e.getId());
+                processEdge(e);
+            });
+
+            // Reconcile deletions. The poll above only adds/updates edges still
+            // present; an edge whose delete callback was missed would otherwise
+            // linger forever — the exact missed-callback problem this refresh
+            // exists to repair. Remove any edge we still hold that the poll no
+            // longer returns.
+            List<String> staleEdgeIds;
+            inventoryLock.readLock().lock();
+            try {
+                staleEdgeIds = edgeIdToInventoryMapping.keySet().stream()
+                        .filter(id -> !liveEdgeIds.contains(id))
+                        .collect(Collectors.toList());
+            } finally {
+                inventoryLock.readLock().unlock();
+            }
+            if (!staleEdgeIds.isEmpty()) {
+                LOG.info("Edge topology refresh removing {} stale edge(s) absent from EdgeDao", staleEdgeIds.size());
+                staleEdgeIds.forEach(this::removeEdgeInventory);
+            }
         } catch (Exception e) {
             LOG.warn("Scheduled edge topology refresh failed: {}", e.getMessage());
         }
@@ -703,27 +726,37 @@ public class DirectInventoryDatasource implements InventoryDatasource, AlarmLife
         processEdge(topologyEdge);
     }
 
-    @SuppressWarnings("Duplicates")
     @Override
     public void onEdgeDeleted(TopologyEdge topologyEdge) {
         LOG.trace("Received delete for edge {}", topologyEdge);
+        removeEdgeInventory(topologyEdge.getId());
+    }
+
+    /**
+     * Remove the inventory derived from a single edge. Shared by the
+     * {@link #onEdgeDeleted} callback and the periodic refresh's deletion
+     * reconciliation (see {@link #refreshEdgeTopology}).
+     */
+    @SuppressWarnings("Duplicates")
+    private void removeEdgeInventory(String edgeId) {
         inventoryLock.writeLock().lock();
         try {
             // Check if this edge had any inventory associated
-            Set<InventoryObject> inventoryForEdge = edgeIdToInventoryMapping.get(topologyEdge.getId());
+            Set<InventoryObject> inventoryForEdge = edgeIdToInventoryMapping.get(edgeId);
 
             if (inventoryForEdge != null) {
                 // Since this edge has been deleted we can clear the inventory associated with it
-                edgeIdToInventoryMapping.remove(topologyEdge.getId());
+                edgeIdToInventoryMapping.remove(edgeId);
 
                 inventoryForEdge.forEach(inventory -> {
                     Set<String> edgeIdsForInventory = inventoryToEdgeIdMapping.get(inventory);
-                    edgeIdsForInventory.remove(topologyEdge.getId());
-
-                    if (edgeIdsForInventory.isEmpty()) {
-                        // This inventory is no longer derived via edges
-                        inventoryFromEdges.remove(inventory);
-                        inventoryToEdgeIdMapping.remove(inventory);
+                    if (edgeIdsForInventory != null) {
+                        edgeIdsForInventory.remove(edgeId);
+                        if (edgeIdsForInventory.isEmpty()) {
+                            // This inventory is no longer derived via edges
+                            inventoryFromEdges.remove(inventory);
+                            inventoryToEdgeIdMapping.remove(inventory);
+                        }
                     }
                     considerInventoryForRemoval(inventory);
                 });

--- a/datasource/opennms-direct/src/test/java/org/opennms/alec/datasource/opennms/jvm/DirectInventoryDatasourceTest.java
+++ b/datasource/opennms-direct/src/test/java/org/opennms/alec/datasource/opennms/jvm/DirectInventoryDatasourceTest.java
@@ -197,6 +197,50 @@ public class DirectInventoryDatasourceTest {
         assertThat(inventory, hasSize(0));
     }
 
+    /**
+     * The periodic refresh must reconcile edges whose delete callback was missed:
+     * an edge still held but no longer returned by the EdgeDao poll should have
+     * its inventory removed (otherwise it lingers forever).
+     */
+    @Test
+    public void refreshRemovesEdgesAbsentFromEdgeDao() {
+        assertThat(dic.getInventoryAndRegisterHandler(inventoryHandler), hasSize(0));
+
+        TopologyProtocol protocol = TopologyProtocol.CDP;
+        TopologySegment segment = mock(TopologySegment.class);
+        when(segment.getId()).thenReturn("segment.id");
+        when(segment.getProtocol()).thenReturn(protocol);
+        when(segment.getSegmentCriteria()).thenReturn("segment:criteria");
+
+        NodeCriteria nc1 = mock(NodeCriteria.class);
+        when(nc1.getId()).thenReturn(99);
+        TopologyPort port1 = mock(TopologyPort.class);
+        when(port1.getId()).thenReturn("port.id");
+        when(port1.getIfIndex()).thenReturn(1);
+        when(port1.getNodeCriteria()).thenReturn(nc1);
+        TopologyEdge edge1 = new EdgeImpl(protocol, "edge.id", port1, segment);
+
+        NodeCriteria nc2 = mock(NodeCriteria.class);
+        when(nc2.getId()).thenReturn(992);
+        TopologyPort port2 = mock(TopologyPort.class);
+        when(port2.getId()).thenReturn("port.id.2");
+        when(port2.getIfIndex()).thenReturn(2);
+        when(port2.getNodeCriteria()).thenReturn(nc2);
+        TopologyEdge edge2 = new EdgeImpl(protocol, "edge.id.2", port2, segment);
+
+        dic.onEdgeAddedOrUpdated(edge1);
+        dic.onEdgeAddedOrUpdated(edge2);
+        assertThat(inventory, hasSize(3));
+
+        // edge2 was deleted but its callback was missed — the poll now returns only edge1.
+        when(mockEdgeDao.getEdges()).thenReturn(Collections.singleton(edge1));
+        dic.refreshEdgeTopology();
+
+        // The refresh reconciles the missed deletion: edge2's link is removed,
+        // leaving the shared segment and edge1's link.
+        assertThat(inventory, hasSize(2));
+    }
+
     @Test
     public void testHandleNewAndDeletedNode() {
         assertThat(dic.getInventoryAndRegisterHandler(inventoryHandler), hasSize(0));

--- a/engine/llm/src/main/java/org/opennms/alec/engine/llm/LlmClusterEngine.java
+++ b/engine/llm/src/main/java/org/opennms/alec/engine/llm/LlmClusterEngine.java
@@ -30,12 +30,19 @@ package org.opennms.alec.engine.llm;
 
 import java.io.IOException;
 import java.time.Instant;
+import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Comparator;
 import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
@@ -56,6 +63,7 @@ import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 
 import edu.uci.ics.jung.graph.Graph;
+import edu.uci.ics.jung.graph.util.Pair;
 import okhttp3.MediaType;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
@@ -69,8 +77,18 @@ public class LlmClusterEngine extends AbstractClusterEngine {
 
     static final String CONFIG_KEY = "LLM_CONFIG";
     static final String CONFIG_CONTEXT = "ALEC_CONFIG";
+    // Shared LLM usage store — same context/record shape as the RCA UsageStore
+    // (features/llm-suggestions) so clustering draws from, and reports into, the
+    // same daily/monthly token budget. Written directly by KV (the engine bundle
+    // cannot depend on the suggestions bundle).
+    static final String USAGE_CONTEXT = "ALEC_LLM_USAGE";
+    static final String CLUSTER_USAGE_MARKER = "llm-clustering";
     static final String TOOL_NAME = "group_alarms";
     static final int MAX_TOKENS = 4096;
+    // Upper bound on alarms serialized into a single clustering request. Beyond
+    // this, the prompt risks exceeding the model's context window (a guaranteed
+    // rejection = no clustering); we cluster the most-recent MAX_ALARMS instead.
+    static final int MAX_ALARMS = 200;
     private static final MediaType JSON = MediaType.parse("application/json; charset=utf-8");
 
     static final String DEFAULT_CLUSTER_PROMPT =
@@ -124,12 +142,31 @@ public class LlmClusterEngine extends AbstractClusterEngine {
 
         LlmConfig config = readLlmConfig();
         if (config == null) {
-            LOG.warn("LLM clustering engine active but LLM is not configured or not enabled; skipping this tick");
+            LOG.warn("LLM clustering engine active but LLM connection is not configured "
+                    + "(endpoint, model and API key are required); skipping this tick");
             return null;
         }
 
+        // Enforce the shared daily/monthly token budget before spending anything.
+        if (budgetExceeded(timestampInMillis, config.dailyTokenLimit, config.monthlyTokenLimit)) {
+            return null;
+        }
+
+        // Bound the request so a high-alarm site doesn't produce a prompt that
+        // overflows the model's context window (which would be rejected outright).
+        Map<String, AlarmInSpaceTime> selected = alarmsById;
+        if (alarmsById.size() > MAX_ALARMS) {
+            LOG.warn("LLM clustering: {} active alarms exceed the per-request cap of {}; "
+                    + "clustering the {} most recent this tick", alarmsById.size(), MAX_ALARMS, MAX_ALARMS);
+            selected = alarmsById.values().stream()
+                    .sorted(Comparator.comparingLong(AlarmInSpaceTime::getAlarmTime).reversed())
+                    .limit(MAX_ALARMS)
+                    .collect(Collectors.toMap(a -> a.getAlarm().getId(), a -> a,
+                            (x, y) -> x, LinkedHashMap::new));
+        }
+
         try {
-            String body = buildRequestBody(alarmsById.values(), config.model, objectMapper);
+            String body = buildRequestBody(selected.values(), g, config.model, objectMapper);
             String url = chatCompletionsUrl(config.baseUrl);
             Request request = new Request.Builder()
                     .url(url)
@@ -147,7 +184,9 @@ public class LlmClusterEngine extends AbstractClusterEngine {
                             truncate(text, 300));
                     return null;
                 }
-                return parseResponse(text, alarmsById, objectMapper);
+                // Record token usage against the shared budget before parsing.
+                recordUsage(text, config.model, timestampInMillis);
+                return parseResponse(text, selected, objectMapper);
             }
         } catch (IOException e) {
             LOG.warn("LLM clustering call failed: {}", e.getMessage());
@@ -178,8 +217,8 @@ public class LlmClusterEngine extends AbstractClusterEngine {
         return map;
     }
 
-    String buildRequestBody(Collection<AlarmInSpaceTime> alarms, String model,
-                            ObjectMapper om) throws IOException {
+    String buildRequestBody(Collection<AlarmInSpaceTime> alarms, Graph<CEVertex, CEEdge> g,
+                            String model, ObjectMapper om) throws IOException {
         ObjectNode root = om.createObjectNode();
         root.put("model", model);
         root.put("max_tokens", MAX_TOKENS);
@@ -190,7 +229,10 @@ public class LlmClusterEngine extends AbstractClusterEngine {
         sysMsg.put("content", clusterPrompt);
         ObjectNode userMsg = messages.addObject();
         userMsg.put("role", "user");
-        userMsg.put("content", renderAlarmsForPrompt(alarms));
+        // The topology-aware grouping the prompt asks for only works if the model
+        // actually sees the connectivity — send the device adjacency, not just
+        // the alarm attributes.
+        userMsg.put("content", renderAlarmsForPrompt(alarms) + renderTopology(alarms, g));
 
         ArrayNode tools = root.putArray("tools");
         ObjectNode tool = tools.addObject();
@@ -229,6 +271,9 @@ public class LlmClusterEngine extends AbstractClusterEngine {
         for (AlarmInSpaceTime ait : alarms) {
             Alarm a = ait.getAlarm();
             sb.append("- [id: ").append(safe(a.getId())).append("] ")
+              // device = the topology vertex the alarm is attached to; it keys
+              // into the connectivity section below.
+              .append("[device: ").append(safe(vertexId(ait))).append("] ")
               .append('[').append(a.getSeverity()).append("] ")
               .append(safe(a.getInventoryObjectType())).append('/')
               .append(safe(a.getInventoryObjectId()))
@@ -239,6 +284,57 @@ public class LlmClusterEngine extends AbstractClusterEngine {
             }
         }
         return sb.toString();
+    }
+
+    /**
+     * Render the device connectivity between the alarm-bearing vertices so the
+     * model can group by topological adjacency. Only edges touching a device
+     * that actually has an alarm in this request are included, keeping the
+     * section relevant and bounded.
+     */
+    private static String renderTopology(Collection<AlarmInSpaceTime> alarms, Graph<CEVertex, CEEdge> g) {
+        Set<String> alarmVertexIds = new HashSet<>();
+        for (AlarmInSpaceTime ait : alarms) {
+            String vid = vertexId(ait);
+            if (!vid.isEmpty()) {
+                alarmVertexIds.add(vid);
+            }
+        }
+        Set<String> links = new LinkedHashSet<>();
+        if (g != null) {
+            for (CEEdge edge : g.getEdges()) {
+                Pair<CEVertex> ends = g.getEndpoints(edge);
+                if (ends == null || ends.getFirst() == null || ends.getSecond() == null) {
+                    continue;
+                }
+                String a = ends.getFirst().getId();
+                String b = ends.getSecond().getId();
+                if (a == null || b == null || a.equals(b)) {
+                    continue;
+                }
+                if (!alarmVertexIds.contains(a) && !alarmVertexIds.contains(b)) {
+                    continue;
+                }
+                // Canonical order so A<->B and B<->A dedup to one line.
+                links.add(a.compareTo(b) <= 0 ? a + " <-> " + b : b + " <-> " + a);
+            }
+        }
+        if (links.isEmpty()) {
+            return "\nTopology (device connectivity): no direct links are known between the "
+                    + "alarm-bearing devices.\n";
+        }
+        StringBuilder sb = new StringBuilder(
+                "\nTopology (device connectivity) — each line is a direct link between two devices "
+                        + "(use it to group alarms on connected devices):\n");
+        for (String link : links) {
+            sb.append("- ").append(link).append('\n');
+        }
+        return sb.toString();
+    }
+
+    private static String vertexId(AlarmInSpaceTime ait) {
+        return ait.getVertex() == null || ait.getVertex().getId() == null
+                ? "" : ait.getVertex().getId();
     }
 
     static List<Cluster<AlarmInSpaceTime>> parseResponse(String json,
@@ -275,20 +371,33 @@ public class LlmClusterEngine extends AbstractClusterEngine {
         }
 
         List<Cluster<AlarmInSpaceTime>> result = new ArrayList<>();
+        // Every alarm belongs to at most one situation. Dedup IDs globally (an
+        // alarm the model repeats across groups is only placed once) and within
+        // a group (a repeated ID cannot inflate a singleton past the 2-alarm
+        // minimum). Only commit a group's IDs as "assigned" once the group is
+        // actually kept.
+        Set<String> assigned = new HashSet<>();
         for (JsonNode group : groups) {
             JsonNode ids = group.get("alarm_ids");
             if (ids == null || !ids.isArray()) continue;
-            Cluster<AlarmInSpaceTime> cluster = new Cluster<>();
+            LinkedHashSet<String> groupIds = new LinkedHashSet<>();
             for (JsonNode idNode : ids) {
                 if (!idNode.isTextual()) continue;
-                AlarmInSpaceTime ait = alarmsById.get(idNode.asText());
-                if (ait != null) {
-                    cluster.addPoint(ait);
+                String id = idNode.asText();
+                if (assigned.contains(id)) continue;      // already placed in a kept group
+                if (alarmsById.containsKey(id)) {
+                    groupIds.add(id);                     // LinkedHashSet dedups within-group
                 }
             }
-            if (!cluster.getPoints().isEmpty()) {
-                result.add(cluster);
+            // The prompt requires at least 2 alarms per group; drop singletons
+            // and empties so repeated-ID inflation cannot create bogus situations.
+            if (groupIds.size() < 2) continue;
+            Cluster<AlarmInSpaceTime> cluster = new Cluster<>();
+            for (String id : groupIds) {
+                cluster.addPoint(alarmsById.get(id));
+                assigned.add(id);
             }
+            result.add(cluster);
         }
         return result;
     }
@@ -300,11 +409,16 @@ public class LlmClusterEngine extends AbstractClusterEngine {
         }
         try {
             JsonNode node = objectMapper.readTree(raw.get());
-            boolean enabled = node.path("enabled").asBoolean(false);
+            // Clustering requires only the shared LLM connection (endpoint,
+            // model, key). It must NOT depend on the "enabled" flag — that flag
+            // toggles Root Cause Analysis, a separate feature. Selecting the LLM
+            // clustering engine is itself the signal to use the LLM for
+            // correlation; gating on the RCA flag would make the engine sit
+            // silently inactive under a fully valid configuration.
             String apiKey = node.path("apiKey").asText("").trim();
             String baseUrl = node.path("baseUrl").asText("").trim();
             String model = node.path("model").asText("").trim();
-            if (!enabled || apiKey.isEmpty() || baseUrl.isEmpty() || model.isEmpty()) {
+            if (apiKey.isEmpty() || baseUrl.isEmpty() || model.isEmpty()) {
                 return null;
             }
             long dailyLimit = Math.max(0, node.path("dailyTokenLimit").asLong(0));
@@ -314,6 +428,94 @@ public class LlmClusterEngine extends AbstractClusterEngine {
             LOG.warn("Malformed LLM config in KV store: {}", e.getMessage());
             return null;
         }
+    }
+
+    /**
+     * True when the shared daily or monthly token budget is already reached, so
+     * this tick must not issue a request. Mirrors the RCA {@code TokenBudget}
+     * semantics exactly: UTC-aligned day/month windows, {@code >=} comparison,
+     * sum of all four token buckets, and limits of 0 meaning unlimited.
+     */
+    boolean budgetExceeded(long now, long dailyLimit, long monthlyLimit) {
+        if (dailyLimit <= 0 && monthlyLimit <= 0) {
+            return false;
+        }
+        long dayStart = startOfUtcDay(now);
+        long monthStart = startOfUtcMonth(now);
+        long dailyUsed = 0;
+        long monthlyUsed = 0;
+        Map<String, String> all = kvStore.enumerateContext(USAGE_CONTEXT);
+        if (all != null) {
+            for (String raw : all.values()) {
+                long ts;
+                long tokens;
+                try {
+                    JsonNode r = objectMapper.readTree(raw);
+                    ts = r.path("ts").asLong(0);
+                    tokens = r.path("inputTokens").asLong(0) + r.path("outputTokens").asLong(0)
+                            + r.path("cacheReadInputTokens").asLong(0)
+                            + r.path("cacheCreationInputTokens").asLong(0);
+                } catch (IOException e) {
+                    continue;
+                }
+                if (dailyLimit > 0 && ts >= dayStart) {
+                    dailyUsed += tokens;
+                }
+                if (monthlyLimit > 0 && ts >= monthStart) {
+                    monthlyUsed += tokens;
+                }
+            }
+        }
+        if (dailyLimit > 0 && dailyUsed >= dailyLimit) {
+            LOG.warn("LLM clustering paused: daily token budget reached ({} of {})", dailyUsed, dailyLimit);
+            return true;
+        }
+        if (monthlyLimit > 0 && monthlyUsed >= monthlyLimit) {
+            LOG.warn("LLM clustering paused: monthly token budget reached ({} of {})", monthlyUsed, monthlyLimit);
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * Record this clustering call's token usage into the shared usage store, in
+     * the same record shape the RCA {@code UsageStore} writes, so it counts
+     * toward the shared budget and appears in the usage dashboard.
+     */
+    void recordUsage(String responseText, String model, long now) {
+        try {
+            JsonNode usage = objectMapper.readTree(responseText).get("usage");
+            if (usage == null) {
+                return;
+            }
+            long prompt = usage.path("prompt_tokens").asLong(0);
+            // cached_tokens is a subset of prompt_tokens (see the RCA usage
+            // handling); store the buckets disjointly to avoid double-counting.
+            long cached = Math.min(prompt,
+                    usage.path("prompt_tokens_details").path("cached_tokens").asLong(0));
+            ObjectNode rec = objectMapper.createObjectNode();
+            rec.put("ts", now);
+            rec.put("situationId", CLUSTER_USAGE_MARKER);
+            rec.put("model", model);
+            rec.put("success", true);
+            rec.put("inputTokens", prompt - cached);
+            rec.put("outputTokens", usage.path("completion_tokens").asLong(0));
+            rec.put("cacheReadInputTokens", cached);
+            rec.put("cacheCreationInputTokens", 0);
+            kvStore.put(UUID.randomUUID().toString(), objectMapper.writeValueAsString(rec), USAGE_CONTEXT);
+        } catch (Exception e) {
+            LOG.warn("Failed to record LLM clustering token usage: {}", e.getMessage());
+        }
+    }
+
+    static long startOfUtcDay(long now) {
+        return Instant.ofEpochMilli(now).atZone(ZoneOffset.UTC).toLocalDate()
+                .atStartOfDay(ZoneOffset.UTC).toInstant().toEpochMilli();
+    }
+
+    static long startOfUtcMonth(long now) {
+        return Instant.ofEpochMilli(now).atZone(ZoneOffset.UTC).toLocalDate()
+                .withDayOfMonth(1).atStartOfDay(ZoneOffset.UTC).toInstant().toEpochMilli();
     }
 
     static String chatCompletionsUrl(String baseUrl) {

--- a/engine/llm/src/test/java/org/opennms/alec/engine/llm/LlmClusterEngineTest.java
+++ b/engine/llm/src/test/java/org/opennms/alec/engine/llm/LlmClusterEngineTest.java
@@ -50,11 +50,15 @@ import org.junit.Before;
 import org.junit.Test;
 import org.opennms.alec.datasource.api.Alarm;
 import org.opennms.alec.engine.cluster.AlarmInSpaceTime;
+import org.opennms.alec.engine.cluster.CEEdge;
 import org.opennms.alec.engine.cluster.CEVertex;
 
 import com.codahale.metrics.MetricRegistry;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+
+import edu.uci.ics.jung.graph.Graph;
+import edu.uci.ics.jung.graph.UndirectedSparseGraph;
 
 /**
  * Unit tests for {@link LlmClusterEngine}. No network calls are made; coverage
@@ -96,7 +100,7 @@ public class LlmClusterEngineTest {
     @Test
     public void buildRequestBodyForcesToolChoice() throws IOException {
         AlarmInSpaceTime ait = makeAlarm("a1", 1L);
-        String body = engine.buildRequestBody(Collections.singletonList(ait), MODEL, om);
+        String body = engine.buildRequestBody(Collections.singletonList(ait), null, MODEL, om);
         JsonNode root = om.readTree(body);
         assertThat(root.get("tool_choice").asText(), equalTo("required"));
     }
@@ -104,7 +108,7 @@ public class LlmClusterEngineTest {
     @Test
     public void buildRequestBodyDeclaresGroupAlarmsTool() throws IOException {
         AlarmInSpaceTime ait = makeAlarm("a1", 1L);
-        String body = engine.buildRequestBody(Collections.singletonList(ait), MODEL, om);
+        String body = engine.buildRequestBody(Collections.singletonList(ait), null, MODEL, om);
         JsonNode root = om.readTree(body);
         JsonNode toolName = root.path("tools").get(0).path("function").path("name");
         assertThat(toolName.asText(), equalTo(LlmClusterEngine.TOOL_NAME));
@@ -113,7 +117,7 @@ public class LlmClusterEngineTest {
     @Test
     public void buildRequestBodyIncludesAlarmIdInUserMessage() throws IOException {
         AlarmInSpaceTime ait = makeAlarm("alarm-xyz", 1L);
-        String body = engine.buildRequestBody(Collections.singletonList(ait), MODEL, om);
+        String body = engine.buildRequestBody(Collections.singletonList(ait), null, MODEL, om);
         JsonNode root = om.readTree(body);
         String userContent = root.path("messages").get(1).path("content").asText();
         assertThat(userContent, containsString("alarm-xyz"));
@@ -122,7 +126,7 @@ public class LlmClusterEngineTest {
     @Test
     public void buildRequestBodyIncludesModelName() throws IOException {
         AlarmInSpaceTime ait = makeAlarm("a1", 1L);
-        String body = engine.buildRequestBody(Collections.singletonList(ait), MODEL, om);
+        String body = engine.buildRequestBody(Collections.singletonList(ait), null, MODEL, om);
         JsonNode root = om.readTree(body);
         assertThat(root.get("model").asText(), equalTo(MODEL));
     }
@@ -130,7 +134,7 @@ public class LlmClusterEngineTest {
     @Test
     public void buildRequestBodySetsMaxTokens() throws IOException {
         AlarmInSpaceTime ait = makeAlarm("a1", 1L);
-        String body = engine.buildRequestBody(Collections.singletonList(ait), MODEL, om);
+        String body = engine.buildRequestBody(Collections.singletonList(ait), null, MODEL, om);
         JsonNode root = om.readTree(body);
         assertThat(root.get("max_tokens").asInt(), equalTo(LlmClusterEngine.MAX_TOKENS));
     }
@@ -182,17 +186,55 @@ public class LlmClusterEngineTest {
     @Test
     public void parseResponseSkipsUnknownAlarmIds() throws IOException {
         AlarmInSpaceTime a1 = makeAlarm("alarm-1", 1L);
-        Map<String, AlarmInSpaceTime> alarmsById = alarmsMap(a1);
+        AlarmInSpaceTime a2 = makeAlarm("alarm-2", 2L);
+        Map<String, AlarmInSpaceTime> alarmsById = alarmsMap(a1, a2);
 
-        // Response references alarm-99 which isn't in the map
+        // Response references alarm-99 which isn't in the map; the two known
+        // alarms still form a valid (>= 2) cluster.
         String json = "{"
                 + "\"choices\":[{\"message\":{\"tool_calls\":[{\"function\":{\"name\":\"group_alarms\","
-                + "\"arguments\":\"{\\\"groups\\\":[{\\\"alarm_ids\\\":[\\\"alarm-1\\\",\\\"alarm-99\\\"]}]}\"}}]}}]}";
+                + "\"arguments\":\"{\\\"groups\\\":[{\\\"alarm_ids\\\":[\\\"alarm-1\\\",\\\"alarm-2\\\",\\\"alarm-99\\\"]}]}\"}}]}}]}";
         List<Cluster<AlarmInSpaceTime>> clusters = LlmClusterEngine.parseResponse(json, alarmsById, om);
 
-        // Only alarm-1 is found; group has 1 point but is still added (engine accepts any non-empty cluster)
         assertThat(clusters.size(), equalTo(1));
-        assertThat(clusters.get(0).getPoints().size(), equalTo(1));
+        assertThat(clusters.get(0).getPoints().size(), equalTo(2));
+    }
+
+    @Test
+    public void parseResponseDropsSingletonGroups() throws IOException {
+        // A group that resolves to a single alarm (per the >=2 rule) is dropped,
+        // so repeated/unknown IDs can't inflate a singleton into a situation.
+        AlarmInSpaceTime a1 = makeAlarm("alarm-1", 1L);
+        Map<String, AlarmInSpaceTime> alarmsById = alarmsMap(a1);
+        String json = groupAlarmsResponse("[\"alarm-1\"]");
+        assertThat(LlmClusterEngine.parseResponse(json, alarmsById, om).size(), equalTo(0));
+    }
+
+    @Test
+    public void parseResponseDedupsRepeatedIdWithinGroup() throws IOException {
+        // A single distinct alarm repeated within one group must not pass the
+        // 2-alarm minimum.
+        AlarmInSpaceTime a1 = makeAlarm("alarm-1", 1L);
+        Map<String, AlarmInSpaceTime> alarmsById = alarmsMap(a1);
+        String json = groupAlarmsResponse("[\"alarm-1\",\"alarm-1\"]");
+        assertThat(LlmClusterEngine.parseResponse(json, alarmsById, om).size(), equalTo(0));
+    }
+
+    @Test
+    public void parseResponseAssignsEachAlarmToAtMostOneCluster() throws IOException {
+        // alarm-1 appears in both groups; it must land in only the first, and
+        // the second group then drops below the 2-alarm minimum.
+        AlarmInSpaceTime a1 = makeAlarm("alarm-1", 1L);
+        AlarmInSpaceTime a2 = makeAlarm("alarm-2", 2L);
+        AlarmInSpaceTime a3 = makeAlarm("alarm-3", 3L);
+        Map<String, AlarmInSpaceTime> alarmsById = alarmsMap(a1, a2, a3);
+        String json = "{"
+                + "\"choices\":[{\"message\":{\"tool_calls\":[{\"function\":{\"name\":\"group_alarms\","
+                + "\"arguments\":\"{\\\"groups\\\":[{\\\"alarm_ids\\\":[\\\"alarm-1\\\",\\\"alarm-2\\\"]},"
+                + "{\\\"alarm_ids\\\":[\\\"alarm-1\\\",\\\"alarm-3\\\"]}]}\"}}]}}]}";
+        List<Cluster<AlarmInSpaceTime>> clusters = LlmClusterEngine.parseResponse(json, alarmsById, om);
+        assertThat(clusters.size(), equalTo(1));
+        assertThat(clusters.get(0).getPoints().size(), equalTo(2));
     }
 
     @Test
@@ -258,7 +300,7 @@ public class LlmClusterEngineTest {
         LlmClusterEngine engineWithNullPrompt =
                 new LlmClusterEngine(new MetricRegistry(), kvStore, om, null);
         AlarmInSpaceTime ait = makeAlarm("a1", 1L);
-        String body = engineWithNullPrompt.buildRequestBody(Collections.singletonList(ait), MODEL, om);
+        String body = engineWithNullPrompt.buildRequestBody(Collections.singletonList(ait), null, MODEL, om);
         JsonNode root = om.readTree(body);
         String sysContent = root.path("messages").get(0).path("content").asText();
         assertThat(sysContent, containsString("group_alarms"));
@@ -269,7 +311,7 @@ public class LlmClusterEngineTest {
         LlmClusterEngine engineWithBlankPrompt =
                 new LlmClusterEngine(new MetricRegistry(), kvStore, om, "   ");
         AlarmInSpaceTime ait = makeAlarm("a1", 1L);
-        String body = engineWithBlankPrompt.buildRequestBody(Collections.singletonList(ait), MODEL, om);
+        String body = engineWithBlankPrompt.buildRequestBody(Collections.singletonList(ait), null, MODEL, om);
         JsonNode root = om.readTree(body);
         String sysContent = root.path("messages").get(0).path("content").asText();
         // Default prompt contains "group_alarms" tool name reference
@@ -281,19 +323,97 @@ public class LlmClusterEngineTest {
         LlmClusterEngine engineWithCustomPrompt =
                 new LlmClusterEngine(new MetricRegistry(), kvStore, om, "MY_CUSTOM_PROMPT");
         AlarmInSpaceTime ait = makeAlarm("a1", 1L);
-        String body = engineWithCustomPrompt.buildRequestBody(Collections.singletonList(ait), MODEL, om);
+        String body = engineWithCustomPrompt.buildRequestBody(Collections.singletonList(ait), null, MODEL, om);
         JsonNode root = om.readTree(body);
         String sysContent = root.path("messages").get(0).path("content").asText();
         assertThat(sysContent, equalTo("MY_CUSTOM_PROMPT"));
     }
 
     // -------------------------------------------------------------------------
+    // Topology (fix: include connectivity)
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void buildRequestBodyIncludesTopologyConnectivity() throws IOException {
+        CEVertex v1 = makeVertex("n1");
+        CEVertex v2 = makeVertex("n2");
+        AlarmInSpaceTime a1 = makeAlarmOn(v1, "alarm-1");
+        AlarmInSpaceTime a2 = makeAlarmOn(v2, "alarm-2");
+        Graph<CEVertex, CEEdge> g = new UndirectedSparseGraph<>();
+        g.addVertex(v1);
+        g.addVertex(v2);
+        g.addEdge(mock(CEEdge.class), v1, v2);
+
+        String body = engine.buildRequestBody(Arrays.asList(a1, a2), g, MODEL, om);
+        String userContent = om.readTree(body).path("messages").get(1).path("content").asText();
+        assertThat(userContent, containsString("n1 <-> n2"));
+        assertThat(userContent, containsString("device: n1"));
+    }
+
+    // -------------------------------------------------------------------------
+    // Shared token budget (fix: enforce + record)
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void budgetExceededTrueWhenDailyLimitReached() {
+        long now = 1_700_000_000_000L;
+        seedUsage(now, 900); // same UTC day as now
+        assertThat(engine.budgetExceeded(now, 500L, 0L), equalTo(true));
+    }
+
+    @Test
+    public void budgetExceededFalseUnderLimitAndWhenUnlimited() {
+        long now = 1_700_000_000_000L;
+        seedUsage(now, 300);
+        assertThat(engine.budgetExceeded(now, 500L, 0L), equalTo(false));
+        assertThat("0 limits mean unlimited", engine.budgetExceeded(now, 0L, 0L), equalTo(false));
+    }
+
+    @Test
+    public void recordUsageSplitsPromptAndCachedTokens() throws IOException {
+        long now = 1_700_000_000_000L;
+        String resp = "{\"usage\":{\"prompt_tokens\":1000,\"completion_tokens\":50,"
+                + "\"prompt_tokens_details\":{\"cached_tokens\":200}}}";
+        engine.recordUsage(resp, MODEL, now);
+
+        Map<String, String> rows = kvStore.enumerateContext(LlmClusterEngine.USAGE_CONTEXT);
+        assertThat(rows.size(), equalTo(1));
+        JsonNode rec = om.readTree(rows.values().iterator().next());
+        assertThat(rec.get("inputTokens").asLong(), equalTo(800L));   // 1000 - 200 cached
+        assertThat(rec.get("outputTokens").asLong(), equalTo(50L));
+        assertThat(rec.get("cacheReadInputTokens").asLong(), equalTo(200L));
+        assertThat(rec.get("situationId").asText(), equalTo(LlmClusterEngine.CLUSTER_USAGE_MARKER));
+    }
+
+    // -------------------------------------------------------------------------
     // Helpers
     // -------------------------------------------------------------------------
+
+    private void seedUsage(long ts, long totalTokens) {
+        kvStore.put(java.util.UUID.randomUUID().toString(),
+                "{\"ts\":" + ts + ",\"inputTokens\":" + totalTokens + ",\"outputTokens\":0,"
+                        + "\"cacheReadInputTokens\":0,\"cacheCreationInputTokens\":0}",
+                LlmClusterEngine.USAGE_CONTEXT);
+    }
+
+    private static CEVertex makeVertex(String id) {
+        CEVertex v = mock(CEVertex.class);
+        when(v.getId()).thenReturn(id);
+        return v;
+    }
+
+    private static AlarmInSpaceTime makeAlarmOn(CEVertex v, String id) {
+        Alarm a = mock(Alarm.class);
+        when(a.getId()).thenReturn(id);
+        when(a.getTime()).thenReturn(1_000L);
+        when(a.getFirstTime()).thenReturn(1_000L);
+        return new AlarmInSpaceTime(v, a);
+    }
 
     private static AlarmInSpaceTime makeAlarm(String id, long nodeId) {
         CEVertex v = mock(CEVertex.class);
         when(v.getNumericId()).thenReturn(nodeId);
+        when(v.getId()).thenReturn("node-" + nodeId);
         Alarm a = mock(Alarm.class);
         when(a.getId()).thenReturn(id);
         when(a.getTime()).thenReturn(1_000L);


### PR DESCRIPTION
Tracked by [ALEC-306](https://opennms.atlassian.net/browse/ALEC-306). Addresses the six review findings against the merged ALEC-301 LLM clustering engine (#157) — the engine could silently stay inactive under a valid config, bypass the token budget, and lacked the topology it needs.

## P1 — correctness
1. **Clustering no longer gated on the RCA `enabled` flag.** `readLlmConfig` required `enabled` — the *Root Cause Analysis* toggle — so an operator with endpoint/model/key set but RCA off got `null` every tick. Clustering now requires only the shared connection fields; selecting the engine is the signal to use it.
2. **Shared token budget enforced + recorded.** Each tick checks UTC daily/monthly usage against the limits (same semantics as the RCA `TokenBudget`) and writes each call's usage into the shared `ALEC_LLM_USAGE` store — so clustering both respects the cap and shows up in the usage dashboard.
3. **Topology is sent to the model.** The request now serializes device adjacency (from the cluster graph) and tags each alarm with its device, so the model can group by connectivity as the prompt/UI/demo assume.

## P2 — robustness
4. **Request bounded.** Beyond `MAX_ALARMS` (200) the engine clusters the most-recent alarms instead of emitting a prompt guaranteed to overflow the context window.
5. **Membership dedup.** `parseResponse` assigns each alarm to at most one cluster (global + within-group) and drops sub-2-alarm groups, so a repeated ID can't span situations or inflate a singleton.
6. **Deleted edges reconciled.** The periodic topology refresh now removes edges ALEC still holds that `EdgeDao` no longer returns (missed delete callback) — the exact class of bug the refresh exists to repair. Removal logic factored into a shared `removeEdgeInventory()`.

## Verification
- **34 engine/llm + 20 datasource tests green**, with new coverage for budget enforcement, usage recording, topology rendering, membership dedup, the ≥2 rule, and stale-edge reconciliation.
- The budget/usage records are written directly to the shared KV store in the same shape as the RCA `UsageStore` (the engine bundle can't depend on features/llm-suggestions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UB6PGc2rpPbojnqbTHU5ND