### PR TITLE
ci: fix PR-Labeler + Auto-Assign 'Resource not accessible by integration' failures

### DIFF
--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -4,6 +4,11 @@ on:
     types: [review_requested, ready_for_review, opened, synchronize, reopened]
     branches:
       - develop
+# The default GITHUB_TOKEN is read-only, so assigning reviewers failed with
+# "Resource not accessible by integration". Grant the write scope it needs.
+permissions:
+  contents: read
+  pull-requests: write
 jobs:
   assign_reviewer:
     if: github.event.pull_request.draft == false

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -3,6 +3,12 @@
 name: PR-Labeler
 # Trigger the workflow on pull request events
 on: [pull_request]
+# The default GITHUB_TOKEN is read-only, so the labeler failed with
+# "Resource not accessible by integration" when it tried to write labels.
+# Grant it the write scope it needs (and read to check out the config file).
+permissions:
+  contents: read
+  pull-requests: write
 jobs:
   label:
     runs-on: ubuntu-latest
@@ -14,4 +20,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           # Here we can override the path for the action configuration. If none is provided, default one is `.github/label-pr.yml`
-          CONFIG_PATH: ${{ secrets.GITHUB_WORKSPACE }}/.github/label-pr.yml
+          # GITHUB_WORKSPACE is a context value, not a secret — the old `secrets.`
+          # reference resolved to empty, silently breaking the config path.
+          CONFIG_PATH: ${{ github.workspace }}/.github/label-pr.yml


### PR DESCRIPTION
Kills the two GitHub Action bots that fail on **every** PR with `Resource not accessible by integration`.

## Cause
Both workflows use the default `GITHUB_TOKEN`, which is **read-only** by default. But:
- **PR-Labeler** tries to *write* labels
- **Auto-Assign** tries to *request reviewers*

So they fail the moment they call the API. They're non-blocking (not required checks), but they spam a red ✗ + failure email on every PR.

## Fix
Add a scoped permissions block to each workflow:
```yaml
permissions:
  contents: read
  pull-requests: write
```
Also fix a long-standing typo in `labeler.yml`: `CONFIG_PATH` referenced `secrets.GITHUB_WORKSPACE` (a context value, not a secret) which resolved to empty and silently broke the config path — now `github.workspace`.

## Note
This PR modifies the workflows themselves, so its own PR-Labeler / Auto-Assign runs should be the first to go **green** (same-repo PRs respect the head branch's `permissions`). If the repo's org policy caps token permissions, the fallback is Settings → Actions → Workflow permissions → Read and write.